### PR TITLE
Incorrect individual icon pack names

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,15 @@ These are the resource dictionaries for the single NuGet packages (if you don't 
 ```xaml
   <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Entypo;component/Themes/PackIconEntypo.xaml" />
 ```
-- for `MahApps.Metro.FontAwesome`  
+- for `MahApps.Metro.IconPacks.FontAwesome`  
 ```xaml
   <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.FontAwesome;component/Themes/PackIconFontAwesome.xaml" />
 ```
-- for `MahApps.Metro.Material`  
+- for `MahApps.Metro.IconPacks.Material`  
 ```xaml
   <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Material;component/Themes/PackIconMaterial.xaml" />
 ```
-- for `MahApps.Metro.Modern`  
+- for `MahApps.Metro.IconPacks.Modern`  
 ```xaml
   <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Modern;component/Themes/PackIconModern.xaml" />
 ```

--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ Here is the resource dictionary content (for `CustomIconPacksStyles.xaml`).
 
 - `MahApps.Metro.IconPacks` [NuGet package](https://www.nuget.org/packages/MahApps.Metro.IconPacks/)
 - `MahApps.Metro.IconPacks.Entypo` [NuGet package](https://www.nuget.org/packages/MahApps.Metro.IconPacks.Entypo/)
-- `MahApps.Metro.FontAwesome` [NuGet package](https://www.nuget.org/packages/MahApps.Metro.IconPacks.FontAwesome/)
-- `MahApps.Metro.Material` [NuGet package](https://www.nuget.org/packages/MahApps.Metro.IconPacks.Material/)
-- `MahApps.Metro.Modern` [NuGet package](https://www.nuget.org/packages/MahApps.Metro.IconPacks.Modern/)
+- `MahApps.Metro.IconPacks.FontAwesome` [NuGet package](https://www.nuget.org/packages/MahApps.Metro.IconPacks.FontAwesome/)
+- `MahApps.Metro.IconPacks.Material` [NuGet package](https://www.nuget.org/packages/MahApps.Metro.IconPacks.Material/)
+- `MahApps.Metro.IconPacks.Modern` [NuGet package](https://www.nuget.org/packages/MahApps.Metro.IconPacks.Modern/)
 
 ## Strong naming
 


### PR DESCRIPTION
I have corrected the little (but significant) annoyances in the README.md. Take a look at the changes, please.