### PR TITLE
Remove ControlzEx dependency

### DIFF
--- a/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
+++ b/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
@@ -14,9 +14,6 @@
     <!-- UWP Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
         <Compile Remove="Converter\MarkupConverter.cs" />
-        <Compile Include="..\paket-files\uwp\ControlzEx\ControlzEx\src\ControlzEx\PackIconBase.cs">
-            <Link>ControlzEx\PackIconBase.cs</Link>
-        </Compile>
         <EmbeddedResource Include="**\*.rd.xml" />
         <Page Include="**\*.xaml" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" SubType="Designer" Generator="MSBuild:Compile" />
         <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />

--- a/src/MahApps.Metro.IconPacks.Core/PackIconBase.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PackIconBase.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+#if NETFX_CORE
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+#else
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+#endif
+
+namespace MahApps.Metro.IconPacks
+{
+    public abstract class PackIconBase : Control
+    {
+        internal abstract void UpdateData();
+    }
+
+    /// <summary>
+    /// Base class for creating an icon control for icon packs.
+    /// </summary>
+    /// <typeparam name="TKind"></typeparam>
+    public abstract class PackIconBase<TKind> : PackIconBase
+    {
+        private static Lazy<IDictionary<TKind, string>> _dataIndex;
+
+        /// <param name="dataIndexFactory">
+        /// Inheritors should provide a factory for setting up the path data index (per icon kind).
+        /// The factory will only be utilised once, across all closed instances (first instantiation wins).
+        /// </param>
+        protected PackIconBase(Func<IDictionary<TKind, string>> dataIndexFactory)
+        {
+            if (dataIndexFactory == null) throw new ArgumentNullException(nameof(dataIndexFactory));
+
+            if (_dataIndex == null)
+                _dataIndex = new Lazy<IDictionary<TKind, string>>(dataIndexFactory);
+        }
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(TKind), typeof(PackIconBase<TKind>), new PropertyMetadata(default(TKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconBase)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public TKind Kind
+        {
+            get { return (TKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+#if NETFX_CORE
+        private static readonly DependencyProperty DataProperty
+            = DependencyProperty.Register(nameof(Data), typeof(string), typeof(PackIconBase<TKind>), new PropertyMetadata(""));
+
+        /// <summary>
+        /// Gets the icon path data for the current <see cref="Kind"/>.
+        /// </summary>
+        public string Data
+        {
+            get { return (string)GetValue(DataProperty); }
+            private set { SetValue(DataProperty, value); }
+        }
+#else
+        private static readonly DependencyPropertyKey DataPropertyKey
+            = DependencyProperty.RegisterReadOnly(nameof(Data), typeof(string), typeof(PackIconBase<TKind>), new PropertyMetadata(""));
+
+        // ReSharper disable once StaticMemberInGenericType
+        public static readonly DependencyProperty DataProperty = DataPropertyKey.DependencyProperty;
+
+        /// <summary>
+        /// Gets the icon path data for the current <see cref="Kind"/>.
+        /// </summary>
+        [TypeConverter(typeof(GeometryConverter))]
+        public string Data
+        {
+            get { return (string)GetValue(DataProperty); }
+            private set { SetValue(DataPropertyKey, value); }
+        }
+#endif
+
+#if NETFX_CORE
+        protected override void OnApplyTemplate()
+#else
+        public override void OnApplyTemplate()
+#endif
+        {
+            base.OnApplyTemplate();
+
+            UpdateData();
+        }
+
+        internal override void UpdateData()
+        {
+            string data = null;
+            if (_dataIndex.Value != null)
+                _dataIndex.Value.TryGetValue(Kind, out data);
+            Data = data;
+        }
+    }
+}

--- a/src/MahApps.Metro.IconPacks.Core/PackIconControl.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PackIconControl.cs
@@ -10,7 +10,6 @@ using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 #endif
-using ControlzEx;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -44,7 +43,7 @@ namespace MahApps.Metro.IconPacks
     /// Class PackIconControl which is the custom base class for any PackIcon control.
     /// </summary>
     /// <typeparam name="TKind">The type of the enum kind.</typeparam>
-    /// <seealso cref="ControlzEx.PackIconBase{TKind}" />
+    /// <seealso cref="PackIconBase{TKind}" />
     public abstract class PackIconControl<TKind> : PackIconBase<TKind>
     {
 

--- a/src/MahApps.Metro.IconPacks.Core/paket.references
+++ b/src/MahApps.Metro.IconPacks.Core/paket.references
@@ -1,2 +1,1 @@
-ControlzEx
 gitlink

--- a/src/MahApps.Metro.IconPacks/PackIconExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconExtension.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Windows.Markup;
 using System.Windows.Media.Animation;
-using ControlzEx;
 
 namespace MahApps.Metro.IconPacks
 {

--- a/src/MahApps.Metro.IconPacks/paket.references
+++ b/src/MahApps.Metro.IconPacks/paket.references
@@ -1,2 +1,1 @@
-ControlzEx
 gitlink

--- a/src/paket.dependencies
+++ b/src/paket.dependencies
@@ -1,6 +1,5 @@
-framework: >= net40
+framework: >= net45
 
-//source https://ci.appveyor.com/nuget/controlzex
 source https://ci.appveyor.com/nuget/mahapps.metro
 source https://api.nuget.org/v3/index.json
 
@@ -10,11 +9,7 @@ nuget Costura.Fody
 nuget JetBrains.Annotations copy_local: true // => PrivateAssets=All, mean all these type of assets are private of the project (so no need to add the deps in the nupkg dep list)
 nuget gitlink prerelease copy_local: true // => PrivateAssets=All, mean all these type of assets are private of the project (so no need to add the deps in the nupkg dep list)
 
-nuget ControlzEx prerelease
 nuget MahApps.Metro prerelease
-
-group UWP
-	github ControlzEx/ControlzEx:e641c9e9346d7ae8c21ca1bf7fa5fb1b86496baa src/ControlzEx/PackIconBase.cs
 
 group cake
 	source https://api.nuget.org/v3/index.json

--- a/src/paket.lock
+++ b/src/paket.lock
@@ -1,15 +1,15 @@
-RESTRICTION: >= net40
+RESTRICTION: >= net45
 NUGET
   remote: https://api.nuget.org/v3/index.json
     ControlzEx (4.0.0-alpha0189)
     Costura.Fody (3.1.4)
       Fody (>= 3.2.6) - restriction: >= net46
-    Fody (3.2.7)
+    Fody (3.2.9)
     gitlink (3.2.0-unstable0040) - copy_local: true
     JetBrains.Annotations (2018.2.1) - copy_local: true
   remote: https://ci.appveyor.com/nuget/mahapps.metro
-    MahApps.Metro (2.0.0-alpha0093)
-      ControlzEx (>= 4.0.0-alpha0188 < 5.0.0-alpha)
+    MahApps.Metro (2.0.0-alpha0102)
+      ControlzEx (>= 4.0.0-alpha0189)
 
 GROUP cake
 RESTRICTION: == net45
@@ -20,11 +20,5 @@ NUGET
     Cake.Paket (4.0)
     Cake.Paket.Module (4.0)
     gitreleasemanager (0.7.1)
-    GitVersion.CommandLine (4.0.0-beta0014)
+    GitVersion.CommandLine (4.0.1-beta0001-0002)
     vswhere (2.5.2)
-
-GROUP UWP
-
-GITHUB
-  remote: ControlzEx/ControlzEx
-    src/ControlzEx/PackIconBase.cs (e641c9e9346d7ae8c21ca1bf7fa5fb1b86496baa)


### PR DESCRIPTION
Remove ControlzEx dependency and use a copy of PackIconBase with the IconPacks namespace instead.
This makes it easier to use this library together with older MahApps releases.