### PR TITLE
New PathIcon IconElement for UWP

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To install the IconPacks, run the following commands in the NuGet Package Manage
 
 ## Usage
 
-If you want all icons together then just install the `MahApps.Metro.IconPacks` NuGet package. You can also only install one of the icon packs if you don't need them all.
+If you want all icons together then just install the `MahApps.Metro.IconPacks` NuGet package, or install one of the separate NuGet packages.
 
 ```xaml
 <StackPanel>
@@ -165,7 +165,24 @@ You can download the latest version of the browser at the [release page](https:/
 </Page>
 ```
 
-## MarkupExtension (only for WPF)
+## PathIcon (UWP only)
+
+The `PathIcon` controls can be used for controls which needs an `IconElement` derived element for their `Icon` property like the `NavigationViewItem`.
+
+```xaml
+<NavigationViewItem>
+    <NavigationViewItem.Icon>
+        <iconPacks:PathIconTypicons Kind="ThumbsUp" />
+    </NavigationViewItem.Icon>
+</NavigationViewItem>
+<NavigationViewItem>
+    <NavigationViewItem.Icon>
+        <iconPacks:PathIconFontAwesome Kind="FlagSolid" />
+    </NavigationViewItem.Icon>
+</NavigationViewItem>
+```
+
+## MarkupExtension (WPF only)
 
 A faster way to get a `Button` (or any other `ContentControl`) with an Icon is to use the MarkupExtension(s).
 
@@ -207,7 +224,7 @@ The MarkupExtension class names had to be renamed, cause the old ones doesn't wo
 <Button Content="{iconPacks:FontAwesome Kind=StarRegular}" />
 ```
 
-## Properties
+## Extra Properties for PackIcon and PathIcon controls
 
 | Property | Description |
 | --- | --- |
@@ -218,9 +235,8 @@ The MarkupExtension class names had to be renamed, cause the old ones doesn't wo
 | `SpinDuration` | Gets or sets the duration of the spinning animation (in seconds). This will also restart the spin animation and works only if `Spin` property is set to `true`. |
 | `SpinEasingFunction` | Gets or sets the EasingFunction (`IEasingFunction`) of the spinning animation. This will also restart the spin animation and works only if `Spin` property is set to `true`. |
 | `SpinAutoReverse` | Gets or sets the AutoReverse of the spinning animation. This will also restart the spin animation and works only if `Spin` property is set to `true`. |
-| `Control.Properties` | All public properties of `Control`, e.g. `Width` and `Height` |
 
-## Custom Styles
+## Custom Styles for PackIcon controls
 
 Sometimes it's necessary to change some properties for all used icon pack controls. All controls have styles which can be use for global changes or anything else.
 

--- a/src/MahApps.Metro.IconPacks.Core/Converter/FlipToScaleValueConverter.cs
+++ b/src/MahApps.Metro.IconPacks.Core/Converter/FlipToScaleValueConverter.cs
@@ -15,6 +15,16 @@ namespace MahApps.Metro.IconPacks.Converter
     /// </summary>
     public class FlipToScaleXValueConverter : IValueConverter
     {
+        private static IValueConverter _instance;
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static FlipToScaleXValueConverter()
+        {
+        }
+
+        public static IValueConverter Instance { get; } = _instance ?? (_instance = new FlipToScaleXValueConverter());
+
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is PackIconFlipOrientation)
@@ -35,7 +45,6 @@ namespace MahApps.Metro.IconPacks.Converter
     /// <summary>
     /// ValueConverter which converts the PackIconFlipOrientation enumeration value to ScaleX value of a ScaleTransformation.
     /// </summary>
-    /// <seealso cref="MahApps.Metro.IconPacks.Converter.MarkupConverter" />
     public class FlipToScaleXValueConverter : MarkupConverter
     {
         private static FlipToScaleXValueConverter _instance;
@@ -53,12 +62,13 @@ namespace MahApps.Metro.IconPacks.Converter
 
         protected override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is PackIconFlipOrientation)
+            if(value is PackIconFlipOrientation)
             {
-                var flip = (PackIconFlipOrientation)value;
+                var flip = (PackIconFlipOrientation) value;
                 var scaleX = flip == PackIconFlipOrientation.Horizontal || flip == PackIconFlipOrientation.Both ? -1 : 1;
                 return scaleX;
             }
+
             return DependencyProperty.UnsetValue;
         }
 
@@ -70,11 +80,21 @@ namespace MahApps.Metro.IconPacks.Converter
 #endif
 
 #if NETFX_CORE
-    /// <summary>
-    /// ValueConverter which converts the PackIconFlipOrientation enumeration value to ScaleY value of a ScaleTransformation.
-    /// </summary>
+/// <summary>
+/// ValueConverter which converts the PackIconFlipOrientation enumeration value to ScaleY value of a ScaleTransformation.
+/// </summary>
     public class FlipToScaleYValueConverter : IValueConverter
     {
+        private static IValueConverter _instance;
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static FlipToScaleYValueConverter()
+        {
+        }
+
+        public static IValueConverter Instance { get; } = _instance ?? (_instance = new FlipToScaleYValueConverter());
+
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is PackIconFlipOrientation)
@@ -95,7 +115,6 @@ namespace MahApps.Metro.IconPacks.Converter
     /// <summary>
     /// ValueConverter which converts the PackIconFlipOrientation enumeration value to ScaleY value of a ScaleTransformation.
     /// </summary>
-    /// <seealso cref="MahApps.Metro.IconPacks.Converter.MarkupConverter" />
     public class FlipToScaleYValueConverter : MarkupConverter
     {
         private static FlipToScaleYValueConverter _instance;
@@ -115,10 +134,11 @@ namespace MahApps.Metro.IconPacks.Converter
         {
             if (value is PackIconFlipOrientation)
             {
-                var flip = (PackIconFlipOrientation)value;
+                var flip = (PackIconFlipOrientation) value;
                 var scaleY = flip == PackIconFlipOrientation.Vertical || flip == PackIconFlipOrientation.Both ? -1 : 1;
                 return scaleY;
             }
+
             return DependencyProperty.UnsetValue;
         }
 

--- a/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
+++ b/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
@@ -9,6 +9,7 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    	<Compile Remove="PathIcon*.cs" />
         <Compile Remove="Attributes\DescriptionAttribute.cs" />
     </ItemGroup>
     <!-- UWP Items include -->

--- a/src/MahApps.Metro.IconPacks.Core/PackIconBase.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PackIconBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 #else
 using System.ComponentModel;
 using System.Windows;
@@ -27,7 +28,7 @@ namespace MahApps.Metro.IconPacks
 
         /// <param name="dataIndexFactory">
         /// Inheritors should provide a factory for setting up the path data index (per icon kind).
-        /// The factory will only be utilised once, across all closed instances (first instantiation wins).
+        /// The factory will only be utilized once, across all closed instances (first instantiation wins).
         /// </param>
         protected PackIconBase(Func<IDictionary<TKind, string>> dataIndexFactory)
         {
@@ -98,9 +99,8 @@ namespace MahApps.Metro.IconPacks
         internal override void UpdateData()
         {
             string data = null;
-            if (_dataIndex.Value != null)
-                _dataIndex.Value.TryGetValue(Kind, out data);
-            Data = data;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks.Core/PackIconControl.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PackIconControl.cs
@@ -212,9 +212,9 @@ namespace MahApps.Metro.IconPacks
             Storyboard.SetTarget(animation, element);
 
 #if NETFX_CORE
-            Storyboard.SetTargetProperty(animation, "(RenderTransform).(TransformGroup.Children)[2].(Angle)");
+            Storyboard.SetTargetProperty(animation, $"(RenderTransform).(TransformGroup.Children)[{transformGroup.Children.Count - 1}].(Angle)");
 #else
-            Storyboard.SetTargetProperty(animation, new PropertyPath("(0).(1)[2].(2)", RenderTransformProperty, TransformGroup.ChildrenProperty, RotateTransform.AngleProperty));
+            Storyboard.SetTargetProperty(animation, new PropertyPath($"(0).(1)[{transformGroup.Children.Count - 1}].(2)", RenderTransformProperty, TransformGroup.ChildrenProperty, RotateTransform.AngleProperty));
 #endif
 
             spinningStoryboard = storyboard;

--- a/src/MahApps.Metro.IconPacks.Core/PackIconFlipOrientation.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PackIconFlipOrientation.cs
@@ -1,0 +1,28 @@
+﻿namespace MahApps.Metro.IconPacks
+{
+    /// <summary>
+    /// Enum PackIconFlipOrientation for the Flip property of any PackIcon control.
+    /// </summary>
+    public enum PackIconFlipOrientation
+    {
+        /// <summary>
+        /// No flip
+        /// </summary>
+        Normal,
+
+        /// <summary>
+        /// Flip the icon horizontal
+        /// </summary>
+        Horizontal,
+
+        /// <summary>
+        /// Flip the icon vertical
+        /// </summary>
+        Vertical,
+
+        /// <summary>
+        /// Flip the icon vertical and horizontal
+        /// </summary>
+        Both
+    }
+}

--- a/src/MahApps.Metro.IconPacks.Core/PathIconBase.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PathIconBase.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
+
+namespace MahApps.Metro.IconPacks
+{
+    public abstract class PathIconBase : PathIcon
+    {
+        internal abstract void UpdateData();
+    }
+
+    /// <summary>
+    /// Base class for creating a PathIcon for IconPacks.
+    /// </summary>
+    /// <typeparam name="TKind"></typeparam>
+    public abstract class PathIconBase<TKind> : PathIconBase
+    {
+        private static Lazy<IDictionary<TKind, string>> _dataIndex;
+
+        /// <param name="dataIndexFactory">
+        /// Inheritors should provide a factory for setting up the path data index (per icon kind).
+        /// The factory will only be utilized once, across all closed instances (first instantiation wins).
+        /// </param>
+        protected PathIconBase(Func<IDictionary<TKind, string>> dataIndexFactory)
+        {
+            if (dataIndexFactory == null) throw new ArgumentNullException(nameof(dataIndexFactory));
+
+            if (_dataIndex == null)
+                _dataIndex = new Lazy<IDictionary<TKind, string>>(dataIndexFactory);
+        }
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(TKind), typeof(PathIconBase<TKind>), new PropertyMetadata(default(TKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PathIconBase) dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public TKind Kind
+        {
+            get { return (TKind) GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        protected override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+
+            UpdateData();
+        }
+
+        internal override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
+        }
+    }
+}

--- a/src/MahApps.Metro.IconPacks.Core/PathIconControl.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PathIconControl.cs
@@ -183,7 +183,7 @@ namespace MahApps.Metro.IconPacks
             storyboard.Children.Add(animation);
             Storyboard.SetTarget(animation, element);
 
-            Storyboard.SetTargetProperty(animation, "(RenderTransform).(TransformGroup.Children)[2].(Angle)");
+            Storyboard.SetTargetProperty(animation, $"(RenderTransform).(TransformGroup.Children)[{transformGroup.Children.Count - 1}].(Angle)");
 
             spinningStoryboard = storyboard;
             storyboard.Begin();

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Entypo.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Entypo.csproj
@@ -13,10 +13,11 @@
     </ItemGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs"/>
         <Compile Include="PackIconExtension.cs"/>
 
-        <Compile Include="*Entypo*.cs"/>
+        <Compile Include="PackIconEntypo*.cs"/>
         <Page Include="Themes\WPF\Entypo\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
         <Page Include="Themes\WPF\PackIconEntypo.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.FontAwesome.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.FontAwesome.csproj
@@ -13,10 +13,11 @@
     </ItemGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs"/>
         <Compile Include="PackIconExtension.cs"/>
 
-        <Compile Include="*FontAwesome*.cs"/>
+        <Compile Include="PackIconFontAwesome*.cs"/>
         <Page Include="Themes\WPF\FontAwesome\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
         <Page Include="Themes\WPF\PackIconFontAwesome.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Material.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Material.csproj
@@ -13,10 +13,11 @@
     </ItemGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs"/>
         <Compile Include="PackIconExtension.cs"/>
 
-        <Compile Include="*Material*.cs" Exclude="*MaterialLight*.cs"/>
+        <Compile Include="PackIconMaterial*.cs" Exclude="PackIconMaterialLight*.cs"/>
         <Page Include="Themes\WPF\Material\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
         <Page Include="Themes\WPF\PackIconMaterial.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.MaterialLight.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.MaterialLight.csproj
@@ -13,10 +13,11 @@
     </ItemGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs"/>
         <Compile Include="PackIconExtension.cs"/>
 
-        <Compile Include="*MaterialLight*.cs"/>
+        <Compile Include="PackIconMaterialLight*.cs"/>
         <Page Include="Themes\WPF\MaterialLight\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
         <Page Include="Themes\WPF\PackIconMaterialLight.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Modern.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Modern.csproj
@@ -13,10 +13,11 @@
     </ItemGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs"/>
         <Compile Include="PackIconExtension.cs"/>
 
-        <Compile Include="*Modern*.cs"/>
+        <Compile Include="PackIconModern*.cs"/>
         <Page Include="Themes\WPF\Modern\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
         <Page Include="Themes\WPF\PackIconModern.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Octicons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Octicons.csproj
@@ -13,10 +13,11 @@
     </ItemGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs"/>
         <Compile Include="PackIconExtension.cs"/>
 
-        <Compile Include="*Octicons*.cs"/>
+        <Compile Include="PackIconOcticons*.cs"/>
         <Page Include="Themes\WPF\Octicons\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
         <Page Include="Themes\WPF\PackIconOcticons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.SimpleIcons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.SimpleIcons.csproj
@@ -13,10 +13,11 @@
     </ItemGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs"/>
         <Compile Include="PackIconExtension.cs"/>
 
-        <Compile Include="*SimpleIcons*.cs"/>
+        <Compile Include="PackIconSimpleIcons*.cs"/>
         <Page Include="Themes\WPF\SimpleIcons\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
         <Page Include="Themes\WPF\PackIconSimpleIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Typicons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Typicons.csproj
@@ -13,10 +13,11 @@
     </ItemGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs"/>
         <Compile Include="PackIconExtension.cs"/>
 
-        <Compile Include="*Typicons*.cs"/>
+        <Compile Include="PackIconTypicons*.cs"/>
         <Page Include="Themes\WPF\Typicons\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
         <Page Include="Themes\WPF\PackIconTypicons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.WeatherIcons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.WeatherIcons.csproj
@@ -13,10 +13,11 @@
     </ItemGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs"/>
         <Compile Include="PackIconExtension.cs"/>
 
-        <Compile Include="*WeatherIcons*.cs"/>
+        <Compile Include="PackIconWeatherIcons*.cs"/>
         <Page Include="Themes\WPF\WeatherIcons\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
         <Page Include="Themes\WPF\PackIconWeatherIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile"/>
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
@@ -13,6 +13,7 @@
     </ItemGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="PathIcon*.cs" />
         <Page Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Generator="MSBuild:Compile" />
     </ItemGroup>
     <!-- UWP Items include -->

--- a/src/MahApps.Metro.IconPacks/PathIconEntypo.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconEntypo.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Media;
+
+namespace MahApps.Metro.IconPacks
+{
+    /// <summary>
+    /// Icons from Entypo+ Icons Font - <see><cref>http://www.entypo.com</cref></see>.
+    /// </summary>
+    public class PathIconEntypo : PathIconControl<PackIconEntypoKind>
+    {
+        public PathIconEntypo() : base(PackIconEntypoDataFactory.Create)
+        {
+        }
+    }
+}

--- a/src/MahApps.Metro.IconPacks/PathIconFontAwesome.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconFontAwesome.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Media;
+
+namespace MahApps.Metro.IconPacks
+{
+    /// <summary>
+    /// Icons from the FontAwesome Icons project, <see><cref>http://fontawesome.io</cref></see>.
+    /// </summary>
+    public class PathIconFontAwesome : PathIconControl<PackIconFontAwesomeKind>
+    {
+        public PathIconFontAwesome() : base(PackIconFontAwesomeDataFactory.Create)
+        {
+        }
+    }
+}

--- a/src/MahApps.Metro.IconPacks/PathIconMaterial.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconMaterial.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Media;
+
+namespace MahApps.Metro.IconPacks
+{
+    /// <summary>
+    /// Icons from the Material Design Icons project, <see><cref>https://materialdesignicons.com/</cref></see>.
+    /// </summary>
+    public class PathIconMaterial : PathIconControl<PackIconMaterialKind>
+    {
+        public PathIconMaterial() : base(PackIconMaterialDataFactory.Create)
+        {
+        }
+    }
+}

--- a/src/MahApps.Metro.IconPacks/PathIconMaterialLight.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconMaterialLight.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Media;
+
+namespace MahApps.Metro.IconPacks
+{
+    /// <summary>
+    /// Icons from the Material Design Icons project, <see><cref>https://materialdesignicons.com/</cref></see>.
+    /// </summary>
+    public class PathIconMaterialLight : PathIconControl<PackIconMaterialLightKind>
+    {
+        public PathIconMaterialLight() : base(PackIconMaterialLightDataFactory.Create)
+        {
+        }
+    }
+}

--- a/src/MahApps.Metro.IconPacks/PathIconModern.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconModern.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Media;
+
+namespace MahApps.Metro.IconPacks
+{
+    /// <summary>
+    /// Icons from the Modern UI Icons project, <see><cref>http://modernuiicons.com</cref></see>.
+    /// </summary>
+    public class PathIconModern : PathIconControl<PackIconModernKind>
+    {
+        public PathIconModern() : base(PackIconModernDataFactory.Create)
+        {
+        }
+    }
+}

--- a/src/MahApps.Metro.IconPacks/PathIconOcticons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconOcticons.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Media;
+
+namespace MahApps.Metro.IconPacks
+{
+    /// <summary>
+    /// Icons from GitHub Octicons - <see><cref>https://octicons.github.com</cref></see>
+    /// </summary>
+    public class PathIconOcticons : PathIconControl<PackIconOcticonsKind>
+    {
+        public PathIconOcticons() : base(PackIconOcticonsDataFactory.Create)
+        {
+        }
+    }
+}

--- a/src/MahApps.Metro.IconPacks/PathIconSimpleIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconSimpleIcons.cs
@@ -1,0 +1,15 @@
+﻿using Windows.UI.Xaml.Media;
+
+namespace MahApps.Metro.IconPacks
+{
+    /// <summary>
+    /// All SVG icons for popular brands, maintained by Dan Leech <see><cref>https://twitter.com/bathtype</cref></see>.
+    /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/danleech/simple-icons</cref></see>.
+    /// </summary>
+    public class PathIconSimpleIcons : PathIconControl<PackIconSimpleIconsKind>
+    {
+        public PathIconSimpleIcons() : base(PackIconSimpleIconsDataFactory.Create)
+        {
+        }
+    }
+}

--- a/src/MahApps.Metro.IconPacks/PathIconTypicons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconTypicons.cs
@@ -1,0 +1,18 @@
+﻿using Windows.UI.Xaml.Media;
+
+namespace MahApps.Metro.IconPacks
+{
+    /// <summary>
+    /// Typicons Icons/Artwork distributed under [CC BY-SA](<see><cref>https://creativecommons.org/licenses/by-sa/3.0/</cref></see>) licence.
+    /// Typicons Font distributed under 'SIL Open Font License' licence.
+    /// </summary>
+    public class PathIconTypicons : PathIconControl<PackIconTypiconsKind>
+    {
+        public PathIconTypicons() : base(PackIconTypiconsDataFactory.Create)
+        {
+            var transformGroup = this.RenderTransform as TransformGroup ?? new TransformGroup();
+            var scaleTransform = new ScaleTransform() {ScaleY = -1};
+            transformGroup.Children.Insert(0, scaleTransform);
+        }
+    }
+}

--- a/src/MahApps.Metro.IconPacks/PathIconWeatherIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconWeatherIcons.cs
@@ -1,0 +1,15 @@
+﻿using Windows.UI.Xaml.Media;
+
+namespace MahApps.Metro.IconPacks
+{
+    /// <summary>
+    /// Weather Icons licensed under [SIL OFL 1.1](<see><cref>http://scripts.sil.org/OFL</cref></see>)
+    /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/erikflowers/weather-icons</cref></see>.
+    /// </summary>
+    public class PathIconWeatherIcons : PathIconControl<PackIconWeatherIconsKind>
+    {
+        public PathIconWeatherIcons() : base(PackIconWeatherIconsDataFactory.Create)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Introduce new PathIcon IconElement for UWP. This can be used for controls which needs an `IconElement` derived element for the Icon property like the `NavigationViewItem`.

```xaml
<NavigationViewItem>
    <NavigationViewItem.Icon>
        <iconPacks:PathIconTypicons Kind="ThumbsUp" />
    </NavigationViewItem.Icon>
</NavigationViewItem>
<NavigationViewItem>
    <NavigationViewItem.Icon>
        <iconPacks:PathIconFontAwesome Kind="FlagSolid" />
    </NavigationViewItem.Icon>
</NavigationViewItem>
```

Closes #98 
