### PR TITLE
Add copy as content and PathIcon actions

### DIFF
--- a/src/MahApps.Metro.IconPacks.Browser/Styles/CustomTabControl.xaml
+++ b/src/MahApps.Metro.IconPacks.Browser/Styles/CustomTabControl.xaml
@@ -213,27 +213,69 @@
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
                             <ContentControl Grid.Row="0" x:Name="IconContent" Content="{Binding}" Focusable="False" IsTabStop="False" />
-                            <Button x:Name="Copy2ClipboardButton"
-                                    Command="{Binding CopyToClipboard}"
-                                    CommandParameter="{Binding}"
-                                    Grid.Row="0"
-                                    Focusable="False"
-                                    IsTabStop="False"
-                                    Visibility="Collapsed"
-                                    Style="{StaticResource CustomMetroCircleButtonStyle}"
-                                    Foreground="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}, Path=Foreground}"
-                                    Padding="0"
-                                    VerticalAlignment="Top"
-                                    HorizontalAlignment="Left"
-                                    BorderThickness="0"
-                                    Width="32"
-                                    Height="32"
-                                    Margin="2">
-                                <Button.ToolTip>
-                                    <TextBlock Text="{Binding Value, StringFormat='{}Copy {0} to Clipboard'}" />
-                                </Button.ToolTip>
-                                <iconPacks:PackIconFontAwesome Kind="ClipboardRegular" />
-                            </Button>
+                            <Grid Grid.Row="0"
+                                  x:Name="Copy2ClipboardActions"
+                                  Visibility="Hidden"
+                                  VerticalAlignment="Top" 
+                                  HorizontalAlignment="Center"
+                                  Focusable="False">
+                                <Grid x:Name="Background" Opacity=".2">
+                                    <Ellipse HorizontalAlignment="Left" Fill="LightGray" Width="22" />
+                                    <Ellipse HorizontalAlignment="Right" Fill="LightGray" Width="22" />
+                                    <Rectangle Margin="11 0" Fill="LightGray" />
+                                </Grid>
+                                <StackPanel Orientation="Horizontal" Margin="11 0">
+                                    <Button Grid.Column="0"
+                                            Width="22"
+                                            Height="22"
+                                            Command="{Binding CopyToClipboard}"
+                                            CommandParameter="{Binding}"                                       
+                                            Style="{StaticResource CustomMetroCircleButtonStyle}"
+                                            Foreground="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}, Path=Foreground}"
+                                            BorderThickness="0"
+                                            HorizontalAlignment="Center"
+                                            Focusable="False"
+                                            IsTabStop="False">
+                                        <Button.ToolTip>
+                                            <TextBlock Text="{Binding Value, StringFormat='{}Copy {0} to clipboard as element'}" />
+                                        </Button.ToolTip>
+                                        <StackPanel Orientation="Horizontal">
+                                            <iconPacks:PackIconMaterial Kind="ChevronLeft" Width="7" Margin="1 0"/>
+                                            <iconPacks:PackIconMaterial Kind="ChevronRight" Width="7" Margin="1 0" />
+                                        </StackPanel>
+                                    </Button>
+                                    <Button Grid.Column="1"
+                                            Width="22"
+                                            Height="22"
+                                            Command="{Binding CopyToClipboardAsContent}"
+                                            CommandParameter="{Binding}"                                       
+                                            Style="{StaticResource CustomMetroCircleButtonStyle}"
+                                            Foreground="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}, Path=Foreground}"
+                                            BorderThickness="0"
+                                            Focusable="False"
+                                            IsTabStop="False">
+                                        <Button.ToolTip>
+                                            <TextBlock Text="{Binding Value, StringFormat='{}Copy {0} to clipboard as content'}" />
+                                        </Button.ToolTip>
+                                        <iconPacks:PackIconMaterial Kind="CodeBraces" Width="14" Height="14" />
+                                    </Button>
+                                    <Button Grid.Column="1"
+                                            Width="22"
+                                            Height="22"
+                                            Command="{Binding CopyToClipboardAsPathIcon}"
+                                            CommandParameter="{Binding}"                                       
+                                            Style="{StaticResource CustomMetroCircleButtonStyle}"
+                                            Foreground="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}, Path=Foreground}"
+                                            BorderThickness="0"
+                                            Focusable="False"
+                                            IsTabStop="False">
+                                        <Button.ToolTip>
+                                            <TextBlock Text="{Binding Value, StringFormat='{}Copy {0} to clipboard as PathIcon element'}" />
+                                        </Button.ToolTip>
+                                        <iconPacks:PackIconFontAwesome Kind="DrawPolygonSolid" Width="14" Height="14" />
+                                    </Button>
+                                </StackPanel>
+                            </Grid>
                             <TextBlock Grid.Row="1"
                                        Margin="2"
                                        HorizontalAlignment="Center"
@@ -242,7 +284,7 @@
                         </Grid>
                         <DataTemplate.Triggers>
                             <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}, Path=IsSelected}" Value="True">
-                                <Setter TargetName="Copy2ClipboardButton" Property="Visibility" Value="Visible" />
+                                <Setter TargetName="Copy2ClipboardActions" Property="Visibility" Value="Visible" />
                             </DataTrigger>
                             <DataTrigger Binding="{Binding IconType}" Value="{x:Type iconPacks:PackIconMaterialKind}">
                                 <Setter TargetName="IconContent" Property="ContentTemplate">

--- a/src/MahApps.Metro.IconPacks.Browser/ViewModels/IconPackViewModel.cs
+++ b/src/MahApps.Metro.IconPacks.Browser/ViewModels/IconPackViewModel.cs
@@ -134,9 +134,38 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
                         Clipboard.SetDataObject(text);
                     }))
                 };
+
+            this.CopyToClipboardAsContent =
+                new SimpleCommand
+                {
+                    CanExecuteDelegate = x => (x != null),
+                    ExecuteDelegate = x => Application.Current.Dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        var icon = (IIconViewModel) x;
+                        var text = $"{{iconPacks:{icon.IconPackType.Name} Kind={icon.Name}}}";
+                        Clipboard.SetDataObject(text);
+                    }))
+                };
+
+            this.CopyToClipboardAsPathIcon =
+                new SimpleCommand
+                {
+                    CanExecuteDelegate = x => (x != null),
+                    ExecuteDelegate = x => Application.Current.Dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        var icon = (IIconViewModel) x;
+                        // The UWP type is in WPF app not available
+                        var text = $"<iconPacks:{icon.IconPackType.Name.Replace("PackIcon", "PathIcon")} Kind=\"{icon.Name}\" />";
+                        Clipboard.SetDataObject(text);
+                    }))
+                };
         }
 
         public ICommand CopyToClipboard { get; }
+
+        public ICommand CopyToClipboardAsContent { get; }
+
+        public ICommand CopyToClipboardAsPathIcon { get; }
 
         public string Name { get; set; }
 

--- a/src/MahApps.Metro.IconPacks.Browser/ViewModels/IconPackViewModel.cs
+++ b/src/MahApps.Metro.IconPacks.Browser/ViewModels/IconPackViewModel.cs
@@ -20,28 +20,26 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
         {
             this.MainViewModel = mainViewModel;
             this.Caption = caption;
-            this.Icons = GetIcons(enumType, packType);
+            this.Icons = new ObservableCollection<IIconViewModel>(GetIcons(enumType, packType).OrderBy(i => i.Name, StringComparer.InvariantCultureIgnoreCase));
             this.PrepareFiltering();
             this.SelectedIcon = this.Icons.First();
         }
 
         public IconPackViewModel(MainViewModel mainViewModel, string caption, Type[] enumTypes, Type[] packTypes)
         {
-            IEnumerable<IIconViewModel> Icons = new List<IIconViewModel>();
+            this.MainViewModel = mainViewModel;
 
-            for (int counter = 0; counter < enumTypes.Length; counter++)
+            var allIcons = Enumerable.Empty<IIconViewModel>();
+            for (var counter = 0; counter < enumTypes.Length; counter++)
             {
-                Icons = Icons.Concat(GetIcons(enumTypes[counter], packTypes[counter]));
+                allIcons = allIcons.Concat(GetIcons(enumTypes[counter], packTypes[counter]));
             }
 
-            this.MainViewModel = mainViewModel;
             this.Caption = caption;
-            this.Icons = Icons.OrderBy((x) => { return x.Name; });
+            this.Icons = new ObservableCollection<IIconViewModel>(allIcons.OrderBy(i => i.Name, StringComparer.InvariantCultureIgnoreCase));
             this.PrepareFiltering();
             this.SelectedIcon = this.Icons.First();
         }
-
-        public MainViewModel MainViewModel { get; private set; }
 
         private void PrepareFiltering()
         {
@@ -65,11 +63,9 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
 
         private static IEnumerable<IIconViewModel> GetIcons(Type enumType, Type packType)
         {
-            return new ObservableCollection<IIconViewModel>(
-                Enum.GetValues(enumType)
-                    .OfType<Enum>()
-                    .Select(k => GetIconViewModel(enumType, packType, k))
-                    .OrderBy(m => m.Name, StringComparer.InvariantCultureIgnoreCase));
+            return Enum.GetValues(enumType)
+                .OfType<Enum>()
+                .Select(k => GetIconViewModel(enumType, packType, k));
         }
 
         private static IIconViewModel GetIconViewModel(Type enumType, Type packType, Enum k)
@@ -85,17 +81,14 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
             };
         }
 
-        public string Caption { get; private set; }
+        public MainViewModel MainViewModel { get; }
+
+        public string Caption { get; }
 
         public IEnumerable<IIconViewModel> Icons
         {
             get { return _icons; }
-            set
-            {
-                if (Equals(value, _icons)) return;
-                _icons = value;
-                OnPropertyChanged();
-            }
+            set { Set(ref _icons, value); }
         }
 
         public string FilterText
@@ -103,22 +96,17 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
             get { return _filterText; }
             set
             {
-                if (value == _filterText) return;
-                _filterText = value;
-                OnPropertyChanged();
-                this._iconsCollectionView.Refresh();
+                if (Set(ref _filterText, value))
+                {
+                    this._iconsCollectionView.Refresh();
+                }
             }
         }
 
         public IIconViewModel SelectedIcon
         {
             get { return _selectedIcon; }
-            set
-            {
-                if (Equals(value, _selectedIcon)) return;
-                _selectedIcon = value;
-                OnPropertyChanged();
-            }
+            set { Set(ref _selectedIcon, value); }
         }
     }
 
@@ -148,18 +136,7 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
                 };
         }
 
-        private ICommand _copyToClipboard;
-
-        public ICommand CopyToClipboard
-        {
-            get { return _copyToClipboard; }
-            set
-            {
-                if (Equals(value, _copyToClipboard)) return;
-                _copyToClipboard = value;
-                OnPropertyChanged();
-            }
-        }
+        public ICommand CopyToClipboard { get; }
 
         public string Name { get; set; }
 

--- a/src/MahApps.Metro.IconPacks.Browser/ViewModels/MainViewModel.cs
+++ b/src/MahApps.Metro.IconPacks.Browser/ViewModels/MainViewModel.cs
@@ -28,8 +28,30 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
                     new IconPackViewModel(this, "WeatherIcons", typeof(PackIconWeatherIconsKind), typeof(PackIconWeatherIcons)),
                     new IconPackViewModel(this, "Typicons", typeof(PackIconTypiconsKind), typeof(PackIconTypicons)),
                     new IconPackViewModel(this, "All",
-                        new[] {typeof(PackIconMaterialKind), typeof(PackIconMaterialLightKind), typeof(PackIconFontAwesomeKind), typeof(PackIconOcticonsKind), typeof(PackIconModernKind), typeof(PackIconEntypoKind), typeof(PackIconSimpleIconsKind), typeof(PackIconWeatherIconsKind), typeof(PackIconTypiconsKind)},
-                        new[] {typeof(PackIconMaterial), typeof(PackIconMaterialLight), typeof(PackIconFontAwesome), typeof(PackIconOcticons), typeof(PackIconModern), typeof(PackIconEntypo), typeof(PackIconSimpleIcons), typeof(PackIconWeatherIcons), typeof(PackIconTypicons)})
+                        new[]
+                        {
+                            typeof(PackIconMaterialKind),
+                            typeof(PackIconMaterialLightKind),
+                            typeof(PackIconFontAwesomeKind),
+                            typeof(PackIconOcticonsKind),
+                            typeof(PackIconModernKind),
+                            typeof(PackIconEntypoKind),
+                            typeof(PackIconSimpleIconsKind),
+                            typeof(PackIconWeatherIconsKind),
+                            typeof(PackIconTypiconsKind)
+                        },
+                        new[]
+                        {
+                            typeof(PackIconMaterial),
+                            typeof(PackIconMaterialLight),
+                            typeof(PackIconFontAwesome),
+                            typeof(PackIconOcticons),
+                            typeof(PackIconModern),
+                            typeof(PackIconEntypo),
+                            typeof(PackIconSimpleIcons),
+                            typeof(PackIconWeatherIcons),
+                            typeof(PackIconTypicons)
+                        })
                 });
             this.IconPacksVersion = Assembly.GetAssembly(typeof(PackIconMaterial)).GetName().Version.ToString();
             this.GoToGitHubCommand =

--- a/src/MahApps.Metro.IconPacks.Browser/ViewModels/MainViewModel.cs
+++ b/src/MahApps.Metro.IconPacks.Browser/ViewModels/MainViewModel.cs
@@ -8,9 +8,6 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
 {
     public class MainViewModel : ViewModelBase
     {
-        private string _appVersion;
-        private string _iconPacksVersion;
-        private ICommand _goToGitHubCommand;
         private Dispatcher _dispatcher;
         private string _filterText;
 
@@ -30,10 +27,10 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
                     new IconPackViewModel(this, "SimpleIcons", typeof(PackIconSimpleIconsKind), typeof(PackIconSimpleIcons)),
                     new IconPackViewModel(this, "WeatherIcons", typeof(PackIconWeatherIconsKind), typeof(PackIconWeatherIcons)),
                     new IconPackViewModel(this, "Typicons", typeof(PackIconTypiconsKind), typeof(PackIconTypicons)),
-                    new IconPackViewModel(this, "All", 
-                                          new Type[] { typeof(PackIconMaterialKind), typeof(PackIconMaterialLightKind), typeof(PackIconFontAwesomeKind), typeof(PackIconOcticonsKind), typeof(PackIconModernKind), typeof(PackIconEntypoKind), typeof(PackIconSimpleIconsKind), typeof(PackIconWeatherIconsKind), typeof(PackIconTypiconsKind) },
-                                          new Type[] { typeof(PackIconMaterial), typeof(PackIconMaterialLight), typeof(PackIconFontAwesome), typeof(PackIconOcticons), typeof(PackIconModern), typeof(PackIconEntypo), typeof(PackIconSimpleIcons), typeof(PackIconWeatherIcons), typeof(PackIconTypicons) })
-                    });
+                    new IconPackViewModel(this, "All",
+                        new[] {typeof(PackIconMaterialKind), typeof(PackIconMaterialLightKind), typeof(PackIconFontAwesomeKind), typeof(PackIconOcticonsKind), typeof(PackIconModernKind), typeof(PackIconEntypoKind), typeof(PackIconSimpleIconsKind), typeof(PackIconWeatherIconsKind), typeof(PackIconTypiconsKind)},
+                        new[] {typeof(PackIconMaterial), typeof(PackIconMaterialLight), typeof(PackIconFontAwesome), typeof(PackIconOcticons), typeof(PackIconModern), typeof(PackIconEntypo), typeof(PackIconSimpleIcons), typeof(PackIconWeatherIcons), typeof(PackIconTypicons)})
+                });
             this.IconPacksVersion = Assembly.GetAssembly(typeof(PackIconMaterial)).GetName().Version.ToString();
             this.GoToGitHubCommand =
                 new SimpleCommand
@@ -45,50 +42,23 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
 
         public ObservableCollection<IconPackViewModel> IconPacks { get; set; }
 
-        public string AppVersion
-        {
-            get { return this._appVersion; }
-            set
-            {
-                if (value == this._appVersion) return;
-                this._appVersion = value;
-                this.OnPropertyChanged();
-            }
-        }
+        public string AppVersion { get; }
 
-        public string IconPacksVersion
-        {
-            get { return this._iconPacksVersion; }
-            set
-            {
-                if (value == this._iconPacksVersion) return;
-                this._iconPacksVersion = value;
-                this.OnPropertyChanged();
-            }
-        }
+        public string IconPacksVersion { get; }
 
-        public ICommand GoToGitHubCommand
-        {
-            get { return this._goToGitHubCommand; }
-            set
-            {
-                if (Equals(value, this._goToGitHubCommand)) return;
-                this._goToGitHubCommand = value;
-                this.OnPropertyChanged();
-            }
-        }
+        public ICommand GoToGitHubCommand { get; }
 
         public string FilterText
         {
             get { return _filterText; }
             set
             {
-                if (value == _filterText) return;
-                _filterText = value;
-                OnPropertyChanged();
-                foreach (var iconPack in this.IconPacks)
+                if (Set(ref _filterText, value))
                 {
-                    this._dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() => iconPack.FilterText = value));
+                    foreach (var iconPack in this.IconPacks)
+                    {
+                        this._dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() => iconPack.FilterText = value));
+                    }
                 }
             }
         }

--- a/src/MahApps.Metro.IconPacks.Browser/ViewModels/ViewModelBase.cs
+++ b/src/MahApps.Metro.IconPacks.Browser/ViewModels/ViewModelBase.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
@@ -7,6 +8,20 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
     public class ViewModelBase : INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler PropertyChanged;
+
+        protected bool Set<T>(ref T field, T newValue = default(T), [CallerMemberName] string propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, newValue))
+            {
+                return false;
+            }
+
+            field = newValue;
+
+            OnPropertyChanged(propertyName);
+
+            return true;
+        }
 
         [NotifyPropertyChangedInvocator]
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)


### PR DESCRIPTION
Add CopyToClipboardAsContent and CopyToClipboardAsPathIcon action buttons to get these options too.

Thx @schdck for the initial PR #52 .

![2018-10-15_23h04_05](https://user-images.githubusercontent.com/658431/46978641-c7946900-d0cf-11e8-8536-9ad64ccfa40d.png)

Closes #52 