### PR TITLE
(GH-130) Rename rotation property

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
     secure: BSPdW2TgnQtoQXXbeDECug==
 
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2019 Preview
 configuration: Release
 test: off
 
@@ -27,7 +27,7 @@ install:
   - cinst netfx-4.7-devpack
   # Install dotnet core 3.0 latest (alpha!!), as this is not provided on AppVeyor yet
   - cinst dotnetcore-sdk --pre
-  - ps: refreshenv
+  - ps: .\build\Install-WindowsSDK.ps1
 
 pull_requests:
   do_not_increment_build_number: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ steps:
     versionSpec: 5.0.2
 
 - powershell: .\build\Install-WindowsSDK.ps1
-  displayName: Install Windows SDK 10.0.14393
+  displayName: Install Windows SDK 10.0.16299
 
 - powershell: .\src\build.ps1 -Script .\src\build.cake --bootstrap
   displayName: 'Build: cake (bootstrap)'

--- a/build/Install-WindowsSDK.ps1
+++ b/build/Install-WindowsSDK.ps1
@@ -1,8 +1,8 @@
 mkdir c:\winsdktemp
 
 $client = new-object System.Net.WebClient
-$client.DownloadFile("https://go.microsoft.com/fwlink/p/?LinkId=838916", "c:\winsdktemp\winsdksetup.exe")
+$client.DownloadFile("https://go.microsoft.com/fwlink/p/?linkid=864422", "c:\winsdktemp\winsdksetup.exe")
 
-Start-Process "c:\winsdktemp\winsdksetup.exe" "/features + /quiet" -NoNewWindow -Wait
+Start-Process "c:\winsdktemp\winsdksetup.exe" "/features OptionId.SigningTools OptionId.UWPManaged OptionId.UWPLocalized /quiet" -NoNewWindow -Wait
 
 refreshenv

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -2,6 +2,7 @@
 
     <!-- Project properties -->
     <PropertyGroup>
+        <TargetFrameworks>net45;net46;net47;netcoreapp3.0;uap10.0;uap10.0.16299</TargetFrameworks>
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <NoError>$(NoError);CS1591</NoError>
         <LangVersion>7.3</LangVersion>

--- a/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
+++ b/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
@@ -3,7 +3,6 @@
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFrameworks>net45;net46;net47;netcoreapp3.0;uap10.0.14393;uap10.0.17763</TargetFrameworks>
         <AssemblyName>MahApps.Metro.IconPacks.Core</AssemblyName>
         <Title>MahApps.Metro.IconPacks.Core</Title>
         <RootNamespace>MahApps.Metro.IconPacks</RootNamespace>

--- a/src/MahApps.Metro.IconPacks.Core/PackIconControl.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PackIconControl.cs
@@ -102,13 +102,12 @@ namespace MahApps.Metro.IconPacks
             set { this.SetValue(FlipProperty, value); }
         }
 
-#if UAP10_0_14393 || !(NETFX_CORE || WINDOWS_UWP)
         /// <summary>
-        /// Identifies the Rotation dependency property.
+        /// Identifies the RotationAngle dependency property.
         /// </summary>
-        public static readonly DependencyProperty RotationProperty
+        public static readonly DependencyProperty RotationAngleProperty
             = DependencyProperty.Register(
-                nameof(Rotation),
+                nameof(RotationAngle),
                 typeof(double),
                 typeof(PackIconControl<TKind>),
 #if NETFX_CORE || WINDOWS_UWP
@@ -127,12 +126,11 @@ namespace MahApps.Metro.IconPacks
         /// Gets or sets the rotation (angle).
         /// </summary>
         /// <value>The rotation.</value>
-        public double Rotation
+        public double RotationAngle
         {
-            get { return (double)this.GetValue(RotationProperty); }
-            set { this.SetValue(RotationProperty, value); }
+            get { return (double)this.GetValue(RotationAngleProperty); }
+            set { this.SetValue(RotationAngleProperty, value); }
         }
-#endif
 
         /// <summary>
         /// Identifies the Spin dependency property.

--- a/src/MahApps.Metro.IconPacks.Core/PathIconControl.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PathIconControl.cs
@@ -54,7 +54,7 @@ namespace MahApps.Metro.IconPacks
             BindingOperations.SetBinding(
                 rotateTransform,
                 RotateTransform.AngleProperty,
-                new Binding() {Path = new PropertyPath(nameof(Rotation)), Source = this, Mode = BindingMode.OneWay});
+                new Binding() {Path = new PropertyPath(nameof(RotationAngle)), Source = this, Mode = BindingMode.OneWay});
             transformGroup.Children.Add(rotateTransform); // rotate
             transformGroup.Children.Add(new RotateTransform()); // spin
             this.RenderTransform = transformGroup;
@@ -99,13 +99,12 @@ namespace MahApps.Metro.IconPacks
             set { this.SetValue(FlipProperty, value); }
         }
 
-#if UAP10_0_14393
         /// <summary>
-        /// Identifies the Rotation dependency property.
+        /// Identifies the RotationAngle dependency property.
         /// </summary>
-        public static readonly DependencyProperty RotationProperty
+        public static readonly DependencyProperty RotationAngleProperty
             = DependencyProperty.Register(
-                nameof(Rotation),
+                nameof(RotationAngle),
                 typeof(double),
                 typeof(PathIconControl<TKind>),
                 new PropertyMetadata(0d));
@@ -114,12 +113,11 @@ namespace MahApps.Metro.IconPacks
         /// Gets or sets the rotation (angle).
         /// </summary>
         /// <value>The rotation.</value>
-        public double Rotation
+        public double RotationAngle
         {
-            get { return (double) this.GetValue(RotationProperty); }
-            set { this.SetValue(RotationProperty, value); }
+            get { return (double) this.GetValue(RotationAngleProperty); }
+            set { this.SetValue(RotationAngleProperty, value); }
         }
-#endif
 
         /// <summary>
         /// Identifies the Spin dependency property.

--- a/src/MahApps.Metro.IconPacks/Directory.build.props
+++ b/src/MahApps.Metro.IconPacks/Directory.build.props
@@ -1,7 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-        <TargetFrameworks>net45;net46;net47;netcoreapp3.0;uap10.0.14393;uap10.0.17763</TargetFrameworks>
         <OutputPath>$(MSBuildProjectDirectory)\bin\$(Configuration)\$(MSBuildProjectName)</OutputPath>
         <IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\$(MSBuildProjectName)</IntermediateOutputPath>
         <GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/src/MahApps.Metro.IconPacks/PackIconExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconExtension.cs
@@ -9,7 +9,7 @@ namespace MahApps.Metro.IconPacks
         double? Width { get; set; }
         double? Height { get; set; }
         PackIconFlipOrientation? Flip { get; set; }
-        double? Rotation { get; set; }
+        double? RotationAngle { get; set; }
         bool? Spin { get; set; }
         bool? SpinAutoReverse { get; set; }
         IEasingFunction SpinEasingFunction { get; set; }
@@ -27,8 +27,8 @@ namespace MahApps.Metro.IconPacks
                 packIcon.Height = packIconExtension.Height.Value;
             if (packIconExtension.Flip != null)
                 packIcon.Flip = packIconExtension.Flip.Value;
-            if (packIconExtension.Rotation != null)
-                packIcon.Rotation = packIconExtension.Rotation.Value;
+            if (packIconExtension.RotationAngle != null)
+                packIcon.RotationAngle = packIconExtension.RotationAngle.Value;
             if (packIconExtension.Spin != null)
                 packIcon.Spin = packIconExtension.Spin.Value;
             if (packIconExtension.SpinAutoReverse != null)
@@ -50,7 +50,7 @@ namespace MahApps.Metro.IconPacks
         public double? Width { get; set; }
         public double? Height { get; set; }
         public PackIconFlipOrientation? Flip { get; set; }
-        public double? Rotation { get; set; }
+        public double? RotationAngle { get; set; }
         public bool? Spin { get; set; }
         public bool? SpinAutoReverse { get; set; }
         public IEasingFunction SpinEasingFunction { get; set; }
@@ -170,7 +170,7 @@ namespace MahApps.Metro.IconPacks
         public double? Width { get; set; }
         public double? Height { get; set; }
         public PackIconFlipOrientation? Flip { get; set; }
-        public double? Rotation { get; set; }
+        public double? RotationAngle { get; set; }
         public bool? Spin { get; set; }
         public bool? SpinAutoReverse { get; set; }
         public IEasingFunction SpinEasingFunction { get; set; }

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconEntypo.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconEntypo.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconFeatherIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconFeatherIcons.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconFontAwesome.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconFontAwesome.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconIonicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconIonicons.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconJamIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconJamIcons.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterial.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterial.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterialDesign.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterialDesign.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterialLight.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterialLight.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconModern.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconModern.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconOcticons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconOcticons.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconSimpleIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconSimpleIcons.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconTypicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconTypicons.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconUnicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconUnicons.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconWeatherIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconWeatherIcons.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconZondicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconZondicons.xaml
@@ -31,7 +31,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconEntypo.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconEntypo.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconFeatherIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconFeatherIcons.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconFontAwesome.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconFontAwesome.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconIonicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconIonicons.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconJamIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconJamIcons.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconMaterial.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconMaterial.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconMaterialDesign.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconMaterialDesign.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconMaterialLight.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconMaterialLight.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconModern.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconModern.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconOcticons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconOcticons.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconSimpleIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconSimpleIcons.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconTypicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconTypicons.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconUnicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconUnicons.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconWeatherIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconWeatherIcons.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconZondicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconZondicons.xaml
@@ -30,7 +30,7 @@
                                                     ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
                                                     ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                                     <RotateTransform x:Name="RotationTransform"
-                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Rotation, Mode=OneWay}" />
+                                                     Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                                     <RotateTransform x:Name="SpinTransform" />
                                 </TransformGroup>
                             </Grid.RenderTransform>

--- a/src/build.cake
+++ b/src/build.cake
@@ -104,7 +104,7 @@ Task("Restore")
         Verbosity = verbosity
         , ToolPath = msBuildPathExe
         , Configuration = configuration
-        , ArgumentCustomization = args => args.Append("/m")
+        , ArgumentCustomization = args => args.Append("/m").Append("/nr:false") // The /nr switch tells msbuild to quite once it’s done
         };
     MSBuild(solution, msBuildSettings.WithTarget("restore"));
 });
@@ -117,7 +117,7 @@ Task("Build")
         Verbosity = verbosity
         , ToolPath = msBuildPathExe
         , Configuration = configuration
-        , ArgumentCustomization = args => args.Append("/m")
+        , ArgumentCustomization = args => args.Append("/m").Append("/nr:false") // The /nr switch tells msbuild to quite once it’s done
         , BinaryLogger = new MSBuildBinaryLogSettings() { Enabled = isLocal }
         };
     MSBuild(solution, msBuildSettings


### PR DESCRIPTION
Rename `Rotation` property to `RotationAngle`.

In UWP v10.0.17763.0 Microsoft introduced the UIElement.Rotation property.

This property conflicts now with our own Rotation property and the solution doesn't compile.

To fix this, we will change the name of `Rotation` to `RotationAngle` for all targets.

Closes #130 
