### PR TITLE
Fix UWP packages

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -62,4 +62,60 @@
         <Resource Include="**\*.png;**\*.jpg;**\*.ico" />
     </ItemGroup>
 
+    <!--
+    // This task disable doc warnings in the auto-generated XamlTypeInfo.g.cs file,
+    // and also hides the public class from intellisense.
+    -->
+    <UsingTask TaskName="XamlTypeInfoBuildTask" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+        <ParameterGroup>
+            <InputFilename ParameterType="System.String" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Reference Include="System.Core" />
+            <Using Namespace="System" />
+            <Using Namespace="Microsoft.Build.Framework" />
+            <Using Namespace="Microsoft.Build.Utilities" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+                //Note: If this task returns 'false' it will break the shared project manager project picker and intellisense.
+                //so we always return true.
+                try {
+                    Log.LogMessage(MessageImportance.Normal, "XamlTypeInfoBuildTask: InputFilename = " + InputFilename);
+                    if (!System.IO.File.Exists(InputFilename)) 
+                    {
+                        return true; 
+                    }
+                    string code = System.IO.File.ReadAllText(InputFilename);
+                    if (code.StartsWith("#pragma warning disable 1591")) //Already modified 
+                        return true; 
+                    Log.LogMessage(MessageImportance.Normal, "XamlTypeInfoBuildTask: File is not modified");
+                    int idx = code.IndexOf("[global::System.CodeDom.Compiler.GeneratedCodeAttribute"); 
+                    if (idx < 0) 
+                    {
+                        return true; 
+                    }
+                    Log.LogMessage(MessageImportance.Normal, "XamlTypeInfoBuildTask: GeneratedCodeAttribute exists");
+                    string insert = "[global::System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]\n    "; 
+                    code = "#pragma warning disable 1591\n" + code.Substring(0, idx) + insert + code.Substring(idx) + 
+                        "#pragma warning restore 1591\n"; 
+                    System.IO.File.WriteAllText(InputFilename, code); 
+                    Log.LogMessage(MessageImportance.Normal, "XamlTypeInfoBuildTask: File is now modified");
+                    return true; 
+                }
+                catch (Exception ex) {
+                    ex = new Exception("XamlTypeInfoBuildTask: " + ex.Message, ex);
+                    Log.LogErrorFromException(ex);
+                    return false;
+                }
+            ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+    <Target Name="XamlTypeInfoBuildTask"
+            Condition="$(TargetFramework.StartsWith('uap')) and '$(DesignTimeBuild)' != 'true'"
+            AfterTargets="MarkupCompilePass2"
+            BeforeTargets="CoreCompile">
+        <XamlTypeInfoBuildTask InputFilename="$(IntermediateOutputPath)\XamlTypeInfo.g.cs" />
+    </Target>
+
 </Project>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -2,8 +2,8 @@
 
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFrameworks>net45;net46;net47;netcoreapp3.0;uap10.0;uap10.0.16299</TargetFrameworks>
-        <!-- <TargetFrameworks>uap10.0.16299</TargetFrameworks> -->
+        <!-- <TargetFrameworks>net45;net46;net47;netcoreapp3.0;uap10.0.15063;uap10.0.16299</TargetFrameworks> -->
+        <TargetFrameworks>net45;net46;net47;netcoreapp3.0;uap10.0.16299</TargetFrameworks>
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <NoError>$(NoError);CS1591</NoError>
         <LangVersion>7.3</LangVersion>
@@ -21,16 +21,17 @@
 
     <!-- UAP 10.0 -->
     <PropertyGroup Condition=" $(TargetFramework.StartsWith('uap')) ">
-        <DefaultTargetPlatformVersion>17763</DefaultTargetPlatformVersion>
+        <DefaultTargetPlatformVersion>16299</DefaultTargetPlatformVersion>
         <DefaultTargetPlatformMinVersion>16299</DefaultTargetPlatformMinVersion>
         <UseWindowsDesktopSdk>true</UseWindowsDesktopSdk>
         <EnableDefaultXamlItems>true</EnableDefaultXamlItems>
         <!-- 8002 is a strong named -> non-strong-named reference -->
         <!-- This is valid for platforms other than .NET Framework (and is needed for the UWP targets -->
         <NoWarn>$(NoWarn);8002</NoWarn>
+    </PropertyGroup>
 
-        <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
-        <ExtrasUwpMetaPackageVersion>6.2.8</ExtrasUwpMetaPackageVersion>
+    <PropertyGroup Condition=" $(TargetFramework.StartsWith('uap')) and '$(Configuration)' == 'Release' ">
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <!-- Add the references for all projects and targets -->
@@ -88,18 +89,16 @@
                     string code = System.IO.File.ReadAllText(InputFilename);
                     if (code.StartsWith("#pragma warning disable 1591")) //Already modified 
                         return true; 
-                    Log.LogMessage(MessageImportance.Normal, "XamlTypeInfoBuildTask: File is not modified");
                     int idx = code.IndexOf("[global::System.CodeDom.Compiler.GeneratedCodeAttribute"); 
                     if (idx < 0) 
                     {
                         return true; 
                     }
-                    Log.LogMessage(MessageImportance.Normal, "XamlTypeInfoBuildTask: GeneratedCodeAttribute exists");
                     string insert = "[global::System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]\n    "; 
                     code = "#pragma warning disable 1591\n" + code.Substring(0, idx) + insert + code.Substring(idx) + 
                         "#pragma warning restore 1591\n"; 
                     System.IO.File.WriteAllText(InputFilename, code); 
-                    Log.LogMessage(MessageImportance.Normal, "XamlTypeInfoBuildTask: File is now modified");
+                    Log.LogMessage(MessageImportance.Normal, "XamlTypeInfoBuildTask: File now modified");
                     return true; 
                 }
                 catch (Exception ex) {
@@ -112,7 +111,7 @@
         </Task>
     </UsingTask>
     <Target Name="XamlTypeInfoBuildTask"
-            Condition="$(TargetFramework.StartsWith('uap')) and '$(DesignTimeBuild)' != 'true'"
+            Condition=" $(TargetFramework.StartsWith('uap')) and '$(DesignTimeBuild)' != 'true' "
             AfterTargets="MarkupCompilePass2"
             BeforeTargets="CoreCompile">
         <XamlTypeInfoBuildTask InputFilename="$(IntermediateOutputPath)\XamlTypeInfo.g.cs" />

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -3,6 +3,7 @@
     <!-- Project properties -->
     <PropertyGroup>
         <TargetFrameworks>net45;net46;net47;netcoreapp3.0;uap10.0;uap10.0.16299</TargetFrameworks>
+        <!-- <TargetFrameworks>uap10.0.16299</TargetFrameworks> -->
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <NoError>$(NoError);CS1591</NoError>
         <LangVersion>7.3</LangVersion>
@@ -20,7 +21,16 @@
 
     <!-- UAP 10.0 -->
     <PropertyGroup Condition=" $(TargetFramework.StartsWith('uap')) ">
+        <DefaultTargetPlatformVersion>17763</DefaultTargetPlatformVersion>
+        <DefaultTargetPlatformMinVersion>16299</DefaultTargetPlatformMinVersion>
+        <UseWindowsDesktopSdk>true</UseWindowsDesktopSdk>
         <EnableDefaultXamlItems>true</EnableDefaultXamlItems>
+        <!-- 8002 is a strong named -> non-strong-named reference -->
+        <!-- This is valid for platforms other than .NET Framework (and is needed for the UWP targets -->
+        <NoWarn>$(NoWarn);8002</NoWarn>
+
+        <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
+        <ExtrasUwpMetaPackageVersion>6.2.8</ExtrasUwpMetaPackageVersion>
     </PropertyGroup>
 
     <!-- Add the references for all projects and targets -->

--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -6,7 +6,6 @@
         <Product>MahApps.Metro.IconPacks</Product>
         <Copyright>Copyright © 2016 - $([System.DateTime]::Today.ToString(yyyy)) MahApps.Metro</Copyright>
         <Description>IconPacks for stylish awesome WPF and UWP applications.</Description>
-
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
         <Version>3.0.0.0</Version>
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
@@ -14,4 +13,22 @@
         <InformationalVersion>3.0.0.0</InformationalVersion>
     </PropertyGroup>
 
+    <Choose>
+        <When Condition=" '$(TargetFramework)' == 'uap10.0' or '$(TargetFramework)' == 'uap10.0.16299' or '$(TargetFramework)' == 'native' ">
+            <!-- UAP versions for uap10.0 where TPMV isn't implied -->
+            <PropertyGroup>
+                <TargetPlatformVersion>10.0.$(DefaultTargetPlatformVersion).0</TargetPlatformVersion>
+                <TargetPlatformMinVersion>10.0.$(DefaultTargetPlatformMinVersion).0</TargetPlatformMinVersion>
+                <DebugType>Full</DebugType>
+            </PropertyGroup>
+            <ItemGroup>
+                <SDKReference Condition="'$(UseWindowsDesktopSdk)' == 'true' " Include="WindowsDesktop, Version=$(TargetPlatformVersion)">
+                    <Name>Windows Desktop Extensions for the UWP</Name>
+                </SDKReference>
+                <SDKReference Condition="'$(UseWindowsMobileSdk)' == 'true' " Include="WindowsMobile, Version=$(TargetPlatformVersion)">
+                    <Name>Windows Mobile Extensions for the UWP</Name>
+                </SDKReference>
+            </ItemGroup>
+        </When>
+    </Choose>
 </Project>

--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -14,25 +14,24 @@
     </PropertyGroup>
 
     <Choose>
-        <When Condition=" '$(TargetFramework)' == 'uap10.0' or '$(TargetFramework)' == 'uap10.0.16299' or '$(TargetFramework)' == 'native' ">
-            <!-- UAP versions for uap10.0 where TPMV isn't implied -->
+        <When Condition=" $(TargetFramework.StartsWith('uap')) ">
             <PropertyGroup>
                 <TargetPlatformVersion>10.0.$(DefaultTargetPlatformVersion).0</TargetPlatformVersion>
                 <TargetPlatformMinVersion>10.0.$(DefaultTargetPlatformMinVersion).0</TargetPlatformMinVersion>
                 <DebugType>Full</DebugType>
             </PropertyGroup>
-            <ItemGroup>
-                <SDKReference Condition="'$(UseWindowsDesktopSdk)' == 'true' " Include="WindowsDesktop, Version=$(TargetPlatformVersion)">
+            <!-- <ItemGroup>
+                <SDKReference Condition=" '$(UseWindowsDesktopSdk)' == 'true' and '$(TargetFramework)' == 'uap10.0.15063' " Include="WindowsDesktop, Version=10.0.15063.0">
                     <Name>Windows Desktop Extensions for the UWP</Name>
                 </SDKReference>
-                <SDKReference Condition="'$(UseWindowsMobileSdk)' == 'true' " Include="WindowsMobile, Version=$(TargetPlatformVersion)">
-                    <Name>Windows Mobile Extensions for the UWP</Name>
+                <SDKReference Condition=" '$(UseWindowsDesktopSdk)' == 'true' and '$(TargetFramework)' == 'uap10.0.16299' " Include="WindowsDesktop, Version=10.0.16299.0">
+                    <Name>Windows Desktop Extensions for the UWP</Name>
                 </SDKReference>
-            </ItemGroup>
+            </ItemGroup> -->
         </When>
     </Choose>
 
-    <Target Name="GetUWPContracts" BeforeTargets="ResolveFrameworkReferences" Condition=" '$(TargetFramework)' == 'uap10.0' or '$(TargetFramework)' == 'uap10.0.16299' "> 
+    <Target Name="GetUWPContracts" BeforeTargets="ResolveFrameworkReferences" Condition=" $(TargetFramework.StartsWith('uap')) ">
         <CreateProperty Value="true">
             <Output PropertyName="ImplicitlyExpandTargetPlatform" TaskParameter="Value"/>
         </CreateProperty>

--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -31,4 +31,17 @@
             </ItemGroup>
         </When>
     </Choose>
+
+    <Target Name="GetUWPContracts" BeforeTargets="ResolveFrameworkReferences" Condition=" '$(TargetFramework)' == 'uap10.0' or '$(TargetFramework)' == 'uap10.0.16299' "> 
+        <CreateProperty Value="true">
+            <Output PropertyName="ImplicitlyExpandTargetPlatform" TaskParameter="Value"/>
+        </CreateProperty>
+        <CreateProperty Value="">
+            <Output PropertyName="WindowsWinmdFile" TaskParameter="Value"/>
+        </CreateProperty>
+        <ItemGroup>
+            <Reference Remove="@(_SdkWindowsImplicitReference)"/>
+        </ItemGroup>
+    </Target>
+
 </Project>

--- a/src/MahApps.Metro.IconPacks.Core/Directory.build.targets
+++ b/src/MahApps.Metro.IconPacks.Core/Directory.build.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <!-- Sign assembly -->
-    <PropertyGroup>
+    <PropertyGroup Condition=" !$(TargetFramework.StartsWith('uap')) ">
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\iconpacks.public.snk</AssemblyOriginatorKeyFile>
         <DelaySign>false</DelaySign>

--- a/src/MahApps.Metro.IconPacks/Directory.build.props
+++ b/src/MahApps.Metro.IconPacks/Directory.build.props
@@ -40,5 +40,9 @@
         </ItemGroup>
     </Target>
 
+    <ItemGroup Label="Package" Condition=" $(TargetFramework.StartsWith('uap')) ">
+        <None Include="Properties\MahApps.Metro.IconPacks.rd.xml" PackagePath="lib\$(TargetFramework)\MahApps.Metro.IconPacks\Properties\MahApps.Metro.IconPacks.rd.xml" Pack="true" />
+    </ItemGroup>
+
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 </Project>

--- a/src/MahApps.Metro.IconPacks/Directory.build.targets
+++ b/src/MahApps.Metro.IconPacks/Directory.build.targets
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <!-- Sign assembly -->
-    <PropertyGroup>
+    <PropertyGroup Condition=" !$(TargetFramework.StartsWith('uap')) ">
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)\..\iconpacks.public.snk</AssemblyOriginatorKeyFile>
         <DelaySign>false</DelaySign>

--- a/src/MahApps.Metro.IconPacks/Properties/MahApps.Metro.IconPacks.rd.xml
+++ b/src/MahApps.Metro.IconPacks/Properties/MahApps.Metro.IconPacks.rd.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This file contains Runtime Directives, specifications about types your application accesses
+    through reflection and other dynamic code patterns. Runtime Directives are used to control the
+    .NET Native optimizer and ensure that it does not remove code accessed by your library. If your
+    library does not do any reflection, then you generally do not need to edit this file. However,
+    if your library reflects over types, especially types passed to it or derived from its types,
+    then you should write Runtime Directives.
+
+    The most common use of reflection in libraries is to discover information about types passed
+    to the library. Runtime Directives have three ways to express requirements on types passed to
+    your library.
+
+    1.  Parameter, GenericParameter, TypeParameter, TypeEnumerableParameter
+        Use these directives to reflect over types passed as a parameter.
+
+    2.  SubTypes
+        Use a SubTypes directive to reflect over types derived from another type.
+
+    3.  AttributeImplies
+        Use an AttributeImplies directive to indicate that your library needs to reflect over
+        types or methods decorated with an attribute.
+
+    For more information on writing Runtime Directives for libraries, please visit
+    http://go.microsoft.com/fwlink/?LinkID=391919
+-->
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="MahApps.Metro.IconPacks">
+  	<Assembly Name="MahApps.Metro.IconPacks" Activate="Required All" Browse="Required All" Serialize="Required All" Dynamic="Required All" />
+    <Assembly Name="MahApps.Metro.IconPacks.Core" Activate="Required All" Browse="Required All" Serialize="Required All" Dynamic="Required All" />
+  </Library>
+</Directives>


### PR DESCRIPTION
More tweaks to get the UWP packages working...

- Take some configuration from Windows Community Toolkit
- Add XamlTypeInfoBuildTask: This task disable doc warnings in the auto-generated XamlTypeInfo.g.cs file, and also hides the public class from intellisense.
- Fix SDK assembly reference for UWP (use the individual contracts instead of the composite Windows.winmd)
- Min target version is now 10.0.16299
- Don't sign assemblies for UWP
- Add Runtime Configuration

Closes #137 
