### PR TITLE
Fix Icons spin when changing visibility (UWP)

### DIFF
--- a/src/MahApps.Metro.IconPacks.Core/PackIconControl.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PackIconControl.cs
@@ -44,7 +44,8 @@ namespace MahApps.Metro.IconPacks
             var packIcon = sender as PackIconControl<TKind>;
             if (packIcon != null && (dp == OpacityProperty || dp == VisibilityProperty))
             {
-                this.Spin = packIcon.Visibility == Visibility.Visible && packIcon.SpinDuration > 0 && packIcon.Opacity > 0;
+                var spin = this.Spin && packIcon.Visibility == Visibility.Visible && packIcon.SpinDuration > 0 && packIcon.Opacity > 0;
+                packIcon.ToggleSpinAnimation(spin);
             }
         }
 #else
@@ -161,15 +162,19 @@ namespace MahApps.Metro.IconPacks
             var packIcon = dependencyObject as PackIconControl<TKind>;
             if (packIcon != null && e.OldValue != e.NewValue && e.NewValue is bool)
             {
-                var spin = (bool)e.NewValue;
-                if (spin)
-                {
-                    packIcon.BeginSpinAnimation();
-                }
-                else
-                {
-                    packIcon.StopSpinAnimation();
-                }
+                packIcon.ToggleSpinAnimation((bool)e.NewValue);
+            }
+        }
+
+        private void ToggleSpinAnimation(bool spin)
+        {
+            if (spin)
+            {
+                this.BeginSpinAnimation();
+            }
+            else
+            {
+                this.StopSpinAnimation();
             }
         }
 

--- a/src/MahApps.Metro.IconPacks.Core/PathIconControl.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PathIconControl.cs
@@ -65,7 +65,8 @@ namespace MahApps.Metro.IconPacks
             var pathIcon = sender as PathIconControl<TKind>;
             if (pathIcon != null && (dp == OpacityProperty || dp == VisibilityProperty))
             {
-                this.Spin = pathIcon.Visibility == Visibility.Visible && pathIcon.SpinDuration > 0 && pathIcon.Opacity > 0;
+                var spin = this.Spin && pathIcon.Visibility == Visibility.Visible && pathIcon.SpinDuration > 0 && pathIcon.Opacity > 0;
+                pathIcon.ToggleSpinAnimation(spin);
             }
         }
 
@@ -134,15 +135,19 @@ namespace MahApps.Metro.IconPacks
             var pathIcon = dependencyObject as PathIconControl<TKind>;
             if (pathIcon != null && e.OldValue != e.NewValue && e.NewValue is bool)
             {
-                var spin = (bool) e.NewValue;
-                if (spin)
-                {
-                    pathIcon.BeginSpinAnimation();
-                }
-                else
-                {
-                    pathIcon.StopSpinAnimation();
-                }
+                pathIcon.ToggleSpinAnimation((bool)e.NewValue);
+            }
+        }
+
+        private void ToggleSpinAnimation(bool spin)
+        {
+            if (spin)
+            {
+                this.BeginSpinAnimation();
+            }
+            else
+            {
+                this.StopSpinAnimation();
             }
         }
 


### PR DESCRIPTION
When changing the visibility of an icon (from Collapsed to Visible) in an UWP project, the icon starts spinning.
This is now fixed after a closer look. In UWP there is no Coerce value callback like in WPF to trigger the spin property changed callback and react to the visibility or opacity. Therefore this has to be done by a toggle mechanism, which was implemented wrong.

Closes #141 
