### PR TITLE
IcanPacks projects as ProjectReference in IconPacks package

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -6,7 +6,7 @@
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <NoError>$(NoError);CS1591</NoError>
         <LangVersion>7.3</LangVersion>
-        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+        <AutoGenerateBindingRedirects Condition="'$(TargetFramework)' != 'netcoreapp3.0'">true</AutoGenerateBindingRedirects>
         <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.xaml;.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/MahApps.Metro.IconPacks.Core/Converter/Converters.xaml
+++ b/src/MahApps.Metro.IconPacks.Core/Converter/Converters.xaml
@@ -1,9 +1,0 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
-
-    <converter:FlipToScaleXValueConverter x:Key="FlipToScaleXValueConverter" />
-    <converter:FlipToScaleYValueConverter x:Key="FlipToScaleYValueConverter" />
-    <converter:NullToUnsetValueConverter x:Key="NullToUnsetValueConverter" />
-
-</ResourceDictionary>

--- a/src/MahApps.Metro.IconPacks.Core/Converter/DataTypeValueConverter.cs
+++ b/src/MahApps.Metro.IconPacks.Core/Converter/DataTypeValueConverter.cs
@@ -1,0 +1,62 @@
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
+using System.Globalization;
+using System.Windows;
+#endif
+
+namespace MahApps.Metro.IconPacks.Converter
+{
+#if (NETFX_CORE || WINDOWS_UWP)
+    public class DataTypeValueConverter : MarkupConverter
+    {
+        private static DataTypeValueConverter _instance;
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static DataTypeValueConverter()
+        {
+        }
+
+        public static IValueConverter Instance { get; } = _instance ?? (_instance = new DataTypeValueConverter());
+
+        protected override object Convert(object value, Type targetType, object parameter, string language)
+        {
+            return value?.GetType();
+        }
+
+        protected override object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            return DependencyProperty.UnsetValue;
+        }
+    }
+#else
+    public class DataTypeValueConverter : MarkupConverter
+    {
+        private static DataTypeValueConverter _instance;
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static DataTypeValueConverter()
+        {
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance ?? (_instance = new DataTypeValueConverter());
+        }
+
+        protected override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value?.GetType();
+        }
+
+        protected override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return DependencyProperty.UnsetValue;
+        }
+    }
+#endif
+}

--- a/src/MahApps.Metro.IconPacks.Core/Converter/FlipToScaleValueConverter.cs
+++ b/src/MahApps.Metro.IconPacks.Core/Converter/FlipToScaleValueConverter.cs
@@ -9,13 +9,13 @@ using System.Windows;
 
 namespace MahApps.Metro.IconPacks.Converter
 {
-#if (NETFX_CORE || WINDOWS_UWP)
     /// <summary>
     /// ValueConverter which converts the PackIconFlipOrientation enumeration value to ScaleX value of a ScaleTransformation.
     /// </summary>
-    public class FlipToScaleXValueConverter : IValueConverter
+#if (NETFX_CORE || WINDOWS_UWP)
+    public class FlipToScaleXValueConverter : MarkupConverter
     {
-        private static IValueConverter _instance;
+        private static FlipToScaleXValueConverter _instance;
 
         // Explicit static constructor to tell C# compiler
         // not to mark type as beforefieldinit
@@ -25,7 +25,7 @@ namespace MahApps.Metro.IconPacks.Converter
 
         public static IValueConverter Instance { get; } = _instance ?? (_instance = new FlipToScaleXValueConverter());
 
-        public object Convert(object value, Type targetType, object parameter, string language)
+        protected override object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is PackIconFlipOrientation)
             {
@@ -33,18 +33,16 @@ namespace MahApps.Metro.IconPacks.Converter
                 var scaleX = flip == PackIconFlipOrientation.Horizontal || flip == PackIconFlipOrientation.Both ? -1 : 1;
                 return scaleX;
             }
+
             return DependencyProperty.UnsetValue;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        protected override object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             return DependencyProperty.UnsetValue;
         }
     }
 #else
-    /// <summary>
-    /// ValueConverter which converts the PackIconFlipOrientation enumeration value to ScaleX value of a ScaleTransformation.
-    /// </summary>
     public class FlipToScaleXValueConverter : MarkupConverter
     {
         private static FlipToScaleXValueConverter _instance;
@@ -79,13 +77,13 @@ namespace MahApps.Metro.IconPacks.Converter
     }
 #endif
 
-#if (NETFX_CORE || WINDOWS_UWP)
     /// <summary>
     /// ValueConverter which converts the PackIconFlipOrientation enumeration value to ScaleY value of a ScaleTransformation.
     /// </summary>
-    public class FlipToScaleYValueConverter : IValueConverter
+#if (NETFX_CORE || WINDOWS_UWP)
+    public class FlipToScaleYValueConverter : MarkupConverter
     {
-        private static IValueConverter _instance;
+        private static FlipToScaleYValueConverter _instance;
 
         // Explicit static constructor to tell C# compiler
         // not to mark type as beforefieldinit
@@ -95,7 +93,7 @@ namespace MahApps.Metro.IconPacks.Converter
 
         public static IValueConverter Instance { get; } = _instance ?? (_instance = new FlipToScaleYValueConverter());
 
-        public object Convert(object value, Type targetType, object parameter, string language)
+        protected override object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is PackIconFlipOrientation)
             {
@@ -103,18 +101,16 @@ namespace MahApps.Metro.IconPacks.Converter
                 var scaleY = flip == PackIconFlipOrientation.Vertical || flip == PackIconFlipOrientation.Both ? -1 : 1;
                 return scaleY;
             }
+
             return DependencyProperty.UnsetValue;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        protected override object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             return DependencyProperty.UnsetValue;
         }
     }
 #else
-    /// <summary>
-    /// ValueConverter which converts the PackIconFlipOrientation enumeration value to ScaleY value of a ScaleTransformation.
-    /// </summary>
     public class FlipToScaleYValueConverter : MarkupConverter
     {
         private static FlipToScaleYValueConverter _instance;

--- a/src/MahApps.Metro.IconPacks.Core/Converter/MarkupConverter.cs
+++ b/src/MahApps.Metro.IconPacks.Core/Converter/MarkupConverter.cs
@@ -1,16 +1,74 @@
 using System;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Markup;
+#else
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Markup;
+#endif
 
 namespace MahApps.Metro.IconPacks.Converter
 {
     /// <summary>
-    /// MarkupConverter is a MarkupExtension which can be used for ValueConverter.
+    /// MarkupConverter is a MarkupExtension which can be used for IValueConverter.
     /// </summary>
-    /// <seealso cref="System.Windows.Markup.MarkupExtension" />
-    /// <seealso cref="System.Windows.Data.IValueConverter" />
+#if (NETFX_CORE || WINDOWS_UWP)
+    [MarkupExtensionReturnType(ReturnType = typeof(IValueConverter))]
+    public abstract class MarkupConverter : MarkupExtension, IValueConverter
+    {
+        protected override object ProvideValue()
+        {
+            return this;
+        }
+
+        /// <summary>
+        /// Converts a value.
+        /// </summary>
+        /// <param name="value">The value produced by the binding source.</param>
+        /// <param name="targetType">The type of the binding target property.</param>
+        /// <param name="parameter">The converter parameter to use.</param>
+        /// <param name="language">The culture language to use in the converter.</param>
+        /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
+        protected abstract object Convert(object value, Type targetType, object parameter, string language);
+
+        /// <summary>
+        /// Converts a value.
+        /// </summary>
+        /// <param name="value">The value that is produced by the binding target.</param>
+        /// <param name="targetType">The type to convert to.</param>
+        /// <param name="parameter">The converter parameter to use.</param>
+        /// <param name="language">The culture language to use in the converter.</param>
+        /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
+        protected abstract object ConvertBack(object value, Type targetType, object parameter, string language);
+
+        object IValueConverter.Convert(object value, Type targetType, object parameter, string language)
+        {
+            try
+            {
+                return Convert(value, targetType, parameter, language);
+            }
+            catch
+            {
+                return DependencyProperty.UnsetValue;
+            }
+        }
+
+        object IValueConverter.ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            try
+            {
+                return ConvertBack(value, targetType, parameter, language);
+            }
+            catch
+            {
+                return DependencyProperty.UnsetValue;
+            }
+        }
+    }
+#else
     [MarkupExtensionReturnType(typeof(IValueConverter))]
     public abstract class MarkupConverter : MarkupExtension, IValueConverter
     {
@@ -28,6 +86,7 @@ namespace MahApps.Metro.IconPacks.Converter
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>A converted value. If the method returns null, the valid null value is used.</returns>
         protected abstract object Convert(object value, Type targetType, object parameter, CultureInfo culture);
+
         /// <summary>
         /// Converts a value.
         /// </summary>
@@ -62,4 +121,5 @@ namespace MahApps.Metro.IconPacks.Converter
             }
         }
     }
+#endif
 }

--- a/src/MahApps.Metro.IconPacks.Core/Converter/NullToUnsetValueConverter.cs
+++ b/src/MahApps.Metro.IconPacks.Core/Converter/NullToUnsetValueConverter.cs
@@ -10,14 +10,27 @@ using System.Windows;
 namespace MahApps.Metro.IconPacks.Converter
 {
 #if (NETFX_CORE || WINDOWS_UWP)
-    public class NullToUnsetValueConverter : IValueConverter
+    public class NullToUnsetValueConverter : MarkupConverter
     {
-        public object Convert(object value, Type targetType, object parameter, string language)
+        private static NullToUnsetValueConverter _instance;
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static NullToUnsetValueConverter()
+        {
+        }
+
+        protected override object ProvideValue()
+        {
+            return _instance ?? (_instance = new NullToUnsetValueConverter());
+        }
+
+        protected override object Convert(object value, Type targetType, object parameter, string language)
         {
             return value ?? DependencyProperty.UnsetValue;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        protected override object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             return DependencyProperty.UnsetValue;
         }

--- a/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
+++ b/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
@@ -18,7 +18,6 @@
     </ItemGroup>
     <!-- UWP Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
-        <Compile Remove="Converter\MarkupConverter.cs" />
         <EmbeddedResource Include="**\*.rd.xml" />
         <Page Include="**\*.xaml" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" SubType="Designer" Generator="MSBuild:Compile" />
         <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />

--- a/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
+++ b/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
@@ -8,8 +8,6 @@
         <RootNamespace>MahApps.Metro.IconPacks</RootNamespace>
         <GenerateLibraryLayout>true</GenerateLibraryLayout>
         <IsPackable>false</IsPackable>
-        <DefaultItemExcludes Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">$(DefaultItemExcludes);$(MSBuildProjectDirectory)\Converter\*.xaml</DefaultItemExcludes>
-        <ExtrasDefaultPageExcludes Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">$(ExtrasDefaultPageExcludes);$(MSBuildProjectDirectory)\Converter\*.xaml</ExtrasDefaultPageExcludes>
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">

--- a/src/MahApps.Metro.IconPacks/Directory.build.props
+++ b/src/MahApps.Metro.IconPacks/Directory.build.props
@@ -1,7 +1,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-        <OutputPath>$(MSBuildProjectDirectory)\bin\$(Configuration)\$(MSBuildProjectName)</OutputPath>
+        <IsBuildingWpfTempProj Condition="$(MSBuildProjectName.Contains('_wpftmp')) != 'true'">false</IsBuildingWpfTempProj>
+        <IsBuildingWpfTempProj Condition="$(MSBuildProjectName.Contains('_wpftmp')) == 'true'">true</IsBuildingWpfTempProj>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <OutputPath Condition="$(IsBuildingWpfTempProj) != 'true'">$(MSBuildProjectDirectory)\bin\$(Configuration)\$(MSBuildProjectName)</OutputPath>
         <IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\$(MSBuildProjectName)</IntermediateOutputPath>
         <GenerateLibraryLayout>true</GenerateLibraryLayout>
         <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage;GetMyPackageFiles</TargetsForTfmSpecificBuildOutput>
@@ -38,9 +43,6 @@
         <ItemGroup>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Core\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Core</TargetPath>
-            </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Core\Converter\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.Core\Converter</TargetPath>
             </BuildOutputInPackage>
         </ItemGroup>
     </Target>

--- a/src/MahApps.Metro.IconPacks/Directory.build.props
+++ b/src/MahApps.Metro.IconPacks/Directory.build.props
@@ -13,7 +13,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\MahApps.Metro.IconPacks.Core\MahApps.Metro.IconPacks.Core.csproj" />
+        <ProjectReference Include="..\MahApps.Metro.IconPacks.Core\MahApps.Metro.IconPacks.Core.csproj">
+            <PrivateAssets>all</PrivateAssets>
+        </ProjectReference>
     </ItemGroup>
 
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
@@ -32,7 +34,7 @@
             <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
         </ItemGroup>
     </Target>
-    <Target Name="GetMyPackageFiles">
+    <Target Name="GetMyPackageFiles" Condition=" '$(_SdkShortFrameworkIdentifier)' == 'uap' ">
         <ItemGroup>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Core\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Core</TargetPath>

--- a/src/MahApps.Metro.IconPacks/Directory.build.props
+++ b/src/MahApps.Metro.IconPacks/Directory.build.props
@@ -13,9 +13,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\MahApps.Metro.IconPacks.Core\MahApps.Metro.IconPacks.Core.csproj">
-            <PrivateAssets>all</PrivateAssets>
-        </ProjectReference>
+        <ProjectReference Include="..\MahApps.Metro.IconPacks.Core\MahApps.Metro.IconPacks.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="**\*.rd.xml" />
+        <Compile Remove="PathIcon*.cs" />
     </ItemGroup>
 
     <!-- known issue https://github.com/NuGet/Home/issues/3891

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.BoxIcons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.BoxIcons.csproj
@@ -1,34 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="Current">
-  <!-- Project properties -->
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);BOXICONS</DefineConstants>
-    <AssemblyName>MahApps.Metro.IconPacks.BoxIcons</AssemblyName>
-    <Title>MahApps.Metro.IconPacks.BoxIcons</Title>
-    <RootNamespace>MahApps.Metro.IconPacks</RootNamespace>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
-  </PropertyGroup>
-  <!-- WPF Items include -->
-  <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-    <Compile Remove="PathIcon*.cs" />
-    <Compile Remove="*.cs" />
-    <Compile Include="PackIconExtension.cs" />
-    <Compile Include="PackIconBoxIcons*.cs" />
-    <Page Generator="MSBuild:Compile" Include="Themes\WPF\BoxIcons\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
-    <Page Generator="MSBuild:Compile" Include="Themes\WPF\PackIconBoxIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
-  </ItemGroup>
-  <!-- UWP Items include -->
-  <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
-    <Compile Remove="*.cs" />
-    <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
-    <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-    <Compile Exclude="*Extension*.cs" Include="*BoxIcons*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-    <Compile Include="PackIconExtension.cs;*BoxIcons*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
-    <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\BoxIcons\*.xaml;Themes\UAP\PackIconBoxIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
-    <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
-  </ItemGroup>
+    <!-- Project properties -->
+    <PropertyGroup>
+        <DefineConstants>$(DefineConstants);BOXICONS</DefineConstants>
+        <AssemblyName>MahApps.Metro.IconPacks.BoxIcons</AssemblyName>
+        <Title>MahApps.Metro.IconPacks.BoxIcons</Title>
+        <RootNamespace>MahApps.Metro.IconPacks</RootNamespace>
+    </PropertyGroup>
+    <!-- WPF Items include -->
+    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="*.cs" />
+        <Compile Include="PackIconExtension.cs" />
+        <Compile Include="PackIconBoxIcons*.cs" />
+        <Page Generator="MSBuild:Compile" Include="Themes\WPF\BoxIcons\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
+        <Page Generator="MSBuild:Compile" Include="Themes\WPF\PackIconBoxIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
+    </ItemGroup>
+    <!-- UWP Items include -->
+    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+        <Compile Remove="*.cs" />
+        <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
+        <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*BoxIcons*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*BoxIcons*.cs" />
+        <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\BoxIcons\*.xaml;Themes\UAP\PackIconBoxIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
+        <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
+    </ItemGroup>
 </Project>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Entypo.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Entypo.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconEntypo*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*Entypo*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*Entypo*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*Entypo*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*Entypo*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\Entypo\*.xaml;Themes\UAP\PackIconEntypo.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.EvaIcons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.EvaIcons.csproj
@@ -1,34 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="Current">
-  <!-- Project properties -->
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);EVAICONS</DefineConstants>
-    <AssemblyName>MahApps.Metro.IconPacks.EvaIcons</AssemblyName>
-    <Title>MahApps.Metro.IconPacks.EvaIcons</Title>
-    <RootNamespace>MahApps.Metro.IconPacks</RootNamespace>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
-  </PropertyGroup>
-  <!-- WPF Items include -->
-  <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-    <Compile Remove="PathIcon*.cs" />
-    <Compile Remove="*.cs" />
-    <Compile Include="PackIconExtension.cs" />
-    <Compile Include="PackIconEvaIcons*.cs" />
-    <Page Generator="MSBuild:Compile" Include="Themes\WPF\EvaIcons\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
-    <Page Generator="MSBuild:Compile" Include="Themes\WPF\PackIconEvaIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
-  </ItemGroup>
-  <!-- UWP Items include -->
-  <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
-    <Compile Remove="*.cs" />
-    <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
-    <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-    <Compile Exclude="*Extension*.cs" Include="*EvaIcons*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-    <Compile Include="PackIconExtension.cs;*EvaIcons*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
-    <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\EvaIcons\*.xaml;Themes\UAP\PackIconEvaIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
-    <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
-  </ItemGroup>
+    <!-- Project properties -->
+    <PropertyGroup>
+        <DefineConstants>$(DefineConstants);EVAICONS</DefineConstants>
+        <AssemblyName>MahApps.Metro.IconPacks.EvaIcons</AssemblyName>
+        <Title>MahApps.Metro.IconPacks.EvaIcons</Title>
+        <RootNamespace>MahApps.Metro.IconPacks</RootNamespace>
+    </PropertyGroup>
+    <!-- WPF Items include -->
+    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="*.cs" />
+        <Compile Include="PackIconExtension.cs" />
+        <Compile Include="PackIconEvaIcons*.cs" />
+        <Page Generator="MSBuild:Compile" Include="Themes\WPF\EvaIcons\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
+        <Page Generator="MSBuild:Compile" Include="Themes\WPF\PackIconEvaIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
+    </ItemGroup>
+    <!-- UWP Items include -->
+    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+        <Compile Remove="*.cs" />
+        <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
+        <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*EvaIcons*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*EvaIcons*.cs" />
+        <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\EvaIcons\*.xaml;Themes\UAP\PackIconEvaIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
+        <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
+    </ItemGroup>
 </Project>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.FeatherIcons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.FeatherIcons.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconFeatherIcons*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*FeatherIcons*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*FeatherIcons*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*FeatherIcons*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*FeatherIcons*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\FeatherIcons\*.xaml;Themes\UAP\PackIconFeatherIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.FontAwesome.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.FontAwesome.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconFontAwesome*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*FontAwesome*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*FontAwesome*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*FontAwesome*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*FontAwesome*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\FontAwesome\*.xaml;Themes\UAP\PackIconFontAwesome.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Ionicons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Ionicons.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconIonicons*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*Ionicons*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*Ionicons*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*Ionicons*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*Ionicons*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\Ionicons\*.xaml;Themes\UAP\PackIconIonicons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.JamIcons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.JamIcons.csproj
@@ -1,34 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="Current">
-  <!-- Project properties -->
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);JAMICONS</DefineConstants>
-    <AssemblyName>MahApps.Metro.IconPacks.JamIcons</AssemblyName>
-    <Title>MahApps.Metro.IconPacks.JamIcons</Title>
-    <RootNamespace>MahApps.Metro.IconPacks</RootNamespace>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
-  </PropertyGroup>
-  <!-- WPF Items include -->
-  <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-    <Compile Remove="PathIcon*.cs" />
-    <Compile Remove="*.cs" />
-    <Compile Include="PackIconExtension.cs" />
-    <Compile Include="PackIconJamIcons*.cs" />
-    <Page Generator="MSBuild:Compile" Include="Themes\WPF\JamIcons\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
-    <Page Generator="MSBuild:Compile" Include="Themes\WPF\PackIconJamIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
-  </ItemGroup>
-  <!-- UWP Items include -->
-  <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
-    <Compile Remove="*.cs" />
-    <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
-    <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-    <Compile Exclude="*Extension*.cs" Include="*JamIcons*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-    <Compile Include="PackIconExtension.cs;*JamIcons*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
-    <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\JamIcons\*.xaml;Themes\UAP\PackIconJamIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
-    <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
-  </ItemGroup>
+    <!-- Project properties -->
+    <PropertyGroup>
+        <DefineConstants>$(DefineConstants);JAMICONS</DefineConstants>
+        <AssemblyName>MahApps.Metro.IconPacks.JamIcons</AssemblyName>
+        <Title>MahApps.Metro.IconPacks.JamIcons</Title>
+        <RootNamespace>MahApps.Metro.IconPacks</RootNamespace>
+    </PropertyGroup>
+    <!-- WPF Items include -->
+    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+        <Compile Remove="*.cs" />
+        <Compile Include="PackIconExtension.cs" />
+        <Compile Include="PackIconJamIcons*.cs" />
+        <Page Generator="MSBuild:Compile" Include="Themes\WPF\JamIcons\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
+        <Page Generator="MSBuild:Compile" Include="Themes\WPF\PackIconJamIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
+    </ItemGroup>
+    <!-- UWP Items include -->
+    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+        <Compile Remove="*.cs" />
+        <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
+        <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*JamIcons*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*JamIcons*.cs" />
+        <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\JamIcons\*.xaml;Themes\UAP\PackIconJamIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
+        <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
+    </ItemGroup>
 </Project>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Material.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Material.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Exclude="PackIconMaterialLight*.cs;PackIconMaterialDesign*.cs" Include="PackIconMaterial*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*MaterialLight*.cs;*MaterialDesign*.cs;*Extension*.cs" Include="*Material*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Exclude="*MaterialLight*.cs;*MaterialDesign*.cs" Include="PackIconExtension.cs;*Material*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*MaterialLight*.cs;*MaterialDesign*.cs;*Extension*.cs" Include="*Material*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Exclude="*MaterialLight*.cs;*MaterialDesign*.cs" Include="PackIconExtension.cs;*Material*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\Material\*.xaml;Themes\UAP\PackIconMaterial.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.MaterialDesign.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.MaterialDesign.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Exclude="PackIconMaterialLight*.cs" Include="PackIconMaterialDesign*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*MaterialLight*.cs;*Extension*.cs" Include="*MaterialDesign*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Exclude="*MaterialLight*.cs" Include="PackIconExtension.cs;*MaterialDesign*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*MaterialLight*.cs;*Extension*.cs" Include="*MaterialDesign*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Exclude="*MaterialLight*.cs" Include="PackIconExtension.cs;*MaterialDesign*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\MaterialDesign\*.xaml;Themes\UAP\PackIconMaterialDesign.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.MaterialLight.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.MaterialLight.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconMaterialLight*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*MaterialLight*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*MaterialLight*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*MaterialLight*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*MaterialLight*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\MaterialLight\*.xaml;Themes\UAP\PackIconMaterialLight.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Modern.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Modern.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconModern*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*Modern*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*Modern*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*Modern*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*Modern*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\Modern\*.xaml;Themes\UAP\PackIconModern.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Octicons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Octicons.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconOcticons*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*Octicons*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*Octicons*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*Octicons*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*Octicons*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\Octicons\*.xaml;Themes\UAP\PackIconOcticons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.SimpleIcons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.SimpleIcons.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconSimpleIcons*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*SimpleIcons*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*SimpleIcons*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*SimpleIcons*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*SimpleIcons*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\SimpleIcons\*.xaml;Themes\UAP\PackIconSimpleIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Typicons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Typicons.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconTypicons*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*Typicons*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*Typicons*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*Typicons*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*Typicons*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\Typicons\*.xaml;Themes\UAP\PackIconTypicons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Unicons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Unicons.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconUnicons*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*Unicons*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*Unicons*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*Unicons*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*Unicons*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\Unicons\*.xaml;Themes\UAP\PackIconUnicons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.WeatherIcons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.WeatherIcons.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconWeatherIcons*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*WeatherIcons*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*WeatherIcons*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*WeatherIcons*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*WeatherIcons*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\WeatherIcons\*.xaml;Themes\UAP\PackIconWeatherIcons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Zondicons.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.Zondicons.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -10,7 +9,6 @@
     </PropertyGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
         <Compile Remove="*.cs" />
         <Compile Include="PackIconExtension.cs" />
         <Compile Include="PackIconZondicons*.cs" />
@@ -22,8 +20,8 @@
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
         <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Compile Exclude="*Extension*.cs" Include="*Zondicons*.cs" Condition=" '$(TargetFramework)' != 'uap10.0.16299' " />
-        <Compile Include="PackIconExtension.cs;*Zondicons*.cs" Condition=" '$(TargetFramework)' == 'uap10.0.16299' " />
+        <Compile Condition=" '$(TargetFramework)' != 'uap10.0.16299' " Exclude="*Extension*.cs" Include="*Zondicons*.cs" />
+        <Compile Condition=" '$(TargetFramework)' == 'uap10.0.16299' " Include="PackIconExtension.cs;*Zondicons*.cs" />
         <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\Zondicons\*.xaml;Themes\UAP\PackIconZondicons.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
@@ -60,9 +60,6 @@
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Core\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Core</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Core\Converter\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.Core\Converter</TargetPath>
-            </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.BoxIcons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.BoxIcons</TargetPath>
             </BuildOutputInPackage>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Project Sdk="MSBuild.Sdk.Extras">
     <!-- Project properties -->
     <PropertyGroup>
@@ -7,21 +6,168 @@
         <AssemblyName>MahApps.Metro.IconPacks</AssemblyName>
         <Title>MahApps.Metro.IconPacks</Title>
         <RootNamespace>MahApps.Metro.IconPacks</RootNamespace>
+        <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage;GetMyPackageFiles</TargetsForTfmSpecificBuildOutput>
     </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="MahApps.Metro.IconPacks.BoxIcons.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.Entypo.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.EvaIcons.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.FeatherIcons.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.FontAwesome.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.Ionicons.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.JamIcons.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.Material.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.MaterialDesign.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.MaterialLight.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.Modern.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.Octicons.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.SimpleIcons.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.Typicons.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.Unicons.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.WeatherIcons.csproj" />
+        <ProjectReference Include="MahApps.Metro.IconPacks.Zondicons.csproj" />
+    </ItemGroup>
     <!-- WPF Items include -->
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
-        <Compile Remove="PathIcon*.cs" />
-        <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
+        <Compile Remove="*.cs" />
+        <Compile Include="PackIconControl*.cs" />
+        <Page Generator="MSBuild:Compile" Include="Themes\WPF\PackIconControl.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
     </ItemGroup>
     <!-- UWP Items include -->
     <ItemGroup Condition=" '$(_SdkShortFrameworkIdentifier)' == 'uap' and '$(TargetFramework)' != 'uap10.0.16299' ">
         <Compile Remove="*Extension*.cs" />
     </ItemGroup>
     <ItemGroup Condition=" '$(_SdkShortFrameworkIdentifier)' == 'uap' ">
-        <Compile Remove="PackIconControl*.cs" />
+        <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
-        <EmbeddedResource Include="**\$(AssemblyName).rd.xml" />
-        <Page Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" Generator="MSBuild:Compile" Include="Themes\UAP\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>
+
+    <ItemGroup Label="Package" Condition=" $(TargetFramework.StartsWith('uap')) ">
+        <None Include="$(OutDir)MahApps.Metro.IconPacks.BoxIcons\Themes\*.*" PackagePath="lib\$(TargetFramework)\MahApps.Metro.IconPacks.BoxIcons\Themes\" Pack="true" />
+    </ItemGroup>
+
+    <!-- known issue https://github.com/NuGet/Home/issues/3891
+         Feature : Allow project reference DLLs to be added to the parent nupkg for pack target like IncludeReferencedProjects in nuget.exe
+
+         Workaround: https://github.com/nuget/home/issues/3891#issuecomment-377319939
+
+         maybe use also BuildOnlySettings -->
+    <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+        <ItemGroup>
+            <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+        </ItemGroup>
+    </Target>
+    <Target Name="GetMyPackageFiles">
+        <ItemGroup>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Core\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Core</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Core\Converter\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Core\Converter</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.BoxIcons\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.BoxIcons</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.BoxIcons\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.BoxIcons\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Entypo\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Entypo</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Entypo\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Entypo\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.EvaIcons\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.EvaIcons</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.EvaIcons\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.EvaIcons\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FeatherIcons\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.FeatherIcons</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FeatherIcons\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.FeatherIcons\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FontAwesome\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.FontAwesome</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FontAwesome\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.FontAwesome\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Ionicons\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Ionicons</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Ionicons\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Ionicons\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.JamIcons\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.JamIcons</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.JamIcons\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.JamIcons\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Material\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Material</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Material\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Material\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialDesign\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.MaterialDesign</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialDesign\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.MaterialDesign\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialLight\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.MaterialLight</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialLight\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.MaterialLight\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Modern\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Modern</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Modern\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Modern\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Octicons\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Octicons</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Octicons\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Octicons\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.SimpleIcons\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.SimpleIcons</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.SimpleIcons\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.SimpleIcons\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Typicons\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Typicons</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Typicons\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Typicons\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Unicons\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Unicons</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Unicons\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Unicons\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.WeatherIcons\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.WeatherIcons</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.WeatherIcons\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.WeatherIcons\Themes</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Zondicons\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Zondicons</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Zondicons\Themes\*.*">
+                <TargetPath>MahApps.Metro.IconPacks.Zondicons\Themes</TargetPath>
+            </BuildOutputInPackage>
+        </ItemGroup>
+    </Target>
 </Project>

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
@@ -31,7 +31,7 @@
     <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
         <Compile Remove="*.cs" />
         <Compile Include="PackIconControl*.cs" />
-        <Page Generator="MSBuild:Compile" Include="Themes\WPF\PackIconControl.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
+        <Page Generator="MSBuild:Compile" Include="Themes\WPF\PackIconControl.xaml;Themes\WPF\IconPacks.xaml;Themes\WPF\Generic.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" />
     </ItemGroup>
     <!-- UWP Items include -->
     <ItemGroup Condition=" '$(_SdkShortFrameworkIdentifier)' == 'uap' and '$(TargetFramework)' != 'uap10.0.16299' ">
@@ -40,6 +40,7 @@
     <ItemGroup Condition=" '$(_SdkShortFrameworkIdentifier)' == 'uap' ">
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\UAP\**\*.*;Themes\WPF\**\*.*" />
+        <Page Generator="MSBuild:Compile" Include="Themes\UAP\IconPacks.xaml;Themes\UAP\Generic.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>
 

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
@@ -43,10 +43,6 @@
         <Compile DependentUpon="%(Filename)" Update="**\*.xaml.cs" />
     </ItemGroup>
 
-    <ItemGroup Label="Package" Condition=" $(TargetFramework.StartsWith('uap')) ">
-        <None Include="$(OutDir)MahApps.Metro.IconPacks.BoxIcons\Themes\*.*" PackagePath="lib\$(TargetFramework)\MahApps.Metro.IconPacks.BoxIcons\Themes\" Pack="true" />
-    </ItemGroup>
-
     <!-- known issue https://github.com/NuGet/Home/issues/3891
          Feature : Allow project reference DLLs to be added to the parent nupkg for pack target like IncludeReferencedProjects in nuget.exe
 
@@ -58,7 +54,7 @@
             <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
         </ItemGroup>
     </Target>
-    <Target Name="GetMyPackageFiles">
+    <Target Name="GetMyPackageFiles" Condition=" '$(_SdkShortFrameworkIdentifier)' == 'uap' ">
         <ItemGroup>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Core\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Core</TargetPath>
@@ -69,105 +65,157 @@
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.BoxIcons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.BoxIcons</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.BoxIcons\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.BoxIcons\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.BoxIcons\Themes\PackIconBoxIcons.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.BoxIcons\Themes\PackIconBoxIcons.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.BoxIcons\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.BoxIcons\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Entypo\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Entypo</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Entypo\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.Entypo\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Entypo\Themes\PackIconEntypo.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Entypo\Themes\PackIconEntypo.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Entypo\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Entypo\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.EvaIcons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.EvaIcons</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.EvaIcons\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.EvaIcons\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.EvaIcons\Themes\PackIconEvaIcons.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.EvaIcons\Themes\PackIconEvaIcons.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.EvaIcons\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.EvaIcons\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FeatherIcons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.FeatherIcons</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FeatherIcons\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.FeatherIcons\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FeatherIcons\Themes\PackIconFeatherIcons.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.FeatherIcons\Themes\PackIconFeatherIcons.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FeatherIcons\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.FeatherIcons\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FontAwesome\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.FontAwesome</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FontAwesome\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.FontAwesome\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FontAwesome\Themes\PackIconFontAwesome.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.FontAwesome\Themes\PackIconFontAwesome.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.FontAwesome\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.FontAwesome\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Ionicons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Ionicons</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Ionicons\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.Ionicons\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Ionicons\Themes\PackIconIonicons.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Ionicons\Themes\PackIconIonicons.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Ionicons\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Ionicons\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.JamIcons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.JamIcons</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.JamIcons\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.JamIcons\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.JamIcons\Themes\PackIconJamIcons.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.JamIcons\Themes\PackIconJamIcons.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.JamIcons\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.JamIcons\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Material\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Material</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Material\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.Material\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Material\Themes\PackIconMaterial.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Material\Themes\PackIconMaterial.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Material\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Material\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialDesign\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.MaterialDesign</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialDesign\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.MaterialDesign\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialDesign\Themes\PackIconMaterialDesign.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.MaterialDesign\Themes\PackIconMaterialDesign.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialDesign\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.MaterialDesign\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialLight\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.MaterialLight</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialLight\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.MaterialLight\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialLight\Themes\PackIconMaterialLight.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.MaterialLight\Themes\PackIconMaterialLight.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.MaterialLight\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.MaterialLight\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Modern\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Modern</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Modern\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.Modern\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Modern\Themes\PackIconModern.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Modern\Themes\PackIconModern.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Modern\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Modern\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Octicons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Octicons</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Octicons\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.Octicons\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Octicons\Themes\PackIconOcticons.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Octicons\Themes\PackIconOcticons.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Octicons\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Octicons\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.SimpleIcons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.SimpleIcons</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.SimpleIcons\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.SimpleIcons\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.SimpleIcons\Themes\PackIconSimpleIcons.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.SimpleIcons\Themes\PackIconSimpleIcons.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.SimpleIcons\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.SimpleIcons\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Typicons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Typicons</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Typicons\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.Typicons\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Typicons\Themes\PackIconTypicons.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Typicons\Themes\PackIconTypicons.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Typicons\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Typicons\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Unicons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Unicons</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Unicons\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.Unicons\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Unicons\Themes\PackIconUnicons.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Unicons\Themes\PackIconUnicons.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Unicons\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Unicons\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.WeatherIcons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.WeatherIcons</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.WeatherIcons\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.WeatherIcons\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.WeatherIcons\Themes\PackIconWeatherIcons.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.WeatherIcons\Themes\PackIconWeatherIcons.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.WeatherIcons\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.WeatherIcons\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Zondicons\*.*">
                 <TargetPath>MahApps.Metro.IconPacks.Zondicons</TargetPath>
             </BuildOutputInPackage>
-            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Zondicons\Themes\*.*">
-                <TargetPath>MahApps.Metro.IconPacks.Zondicons\Themes</TargetPath>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Zondicons\Themes\PackIconZondicons.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Zondicons\Themes\PackIconZondicons.xaml</TargetPath>
+            </BuildOutputInPackage>
+            <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.Zondicons\Themes\Generic.xaml">
+                <TargetPath>MahApps.Metro.IconPacks.Zondicons\Themes\Generic.xaml</TargetPath>
             </BuildOutputInPackage>
         </ItemGroup>
     </Target>
+
 </Project>

--- a/src/MahApps.Metro.IconPacks/PackIconBoxIconsDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconBoxIconsDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconBoxIconsDataFactory
+    public static class PackIconBoxIconsDataFactory
     {
-        internal static IDictionary<PackIconBoxIconsKind, string> Create()
+        public static IDictionary<PackIconBoxIconsKind, string> Create()
         {
             return new Dictionary<PackIconBoxIconsKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconControlDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconControlDataFactory.cs
@@ -11,6 +11,11 @@ namespace MahApps.Metro.IconPacks
         internal static IDictionary<Enum, string> Create()
         {
             var dictionary = new Dictionary<Enum, string>();
+            foreach (var packIcon in PackIconBoxIconsDataFactory.Create())
+            {
+                dictionary.Add(packIcon.Key, packIcon.Value);
+            }
+
             foreach (var packIcon in PackIconEntypoDataFactory.Create())
             {
                 dictionary.Add(packIcon.Key, packIcon.Value);

--- a/src/MahApps.Metro.IconPacks/PackIconEntypoDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconEntypoDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconEntypoDataFactory
+    public static class PackIconEntypoDataFactory
     {
-        internal static IDictionary<PackIconEntypoKind, string> Create()
+        public static IDictionary<PackIconEntypoKind, string> Create()
         {
             return new Dictionary<PackIconEntypoKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconEvaIconsDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconEvaIconsDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconEvaIconsDataFactory
+    public static class PackIconEvaIconsDataFactory
     {
-        internal static IDictionary<PackIconEvaIconsKind, string> Create()
+        public static IDictionary<PackIconEvaIconsKind, string> Create()
         {
             return new Dictionary<PackIconEvaIconsKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconExtension.cs
@@ -51,10 +51,28 @@ namespace MahApps.Metro.IconPacks
         public override object ProvideValue(IServiceProvider serviceProvider)
 #endif
         {
+#if ALL || BOXICONS
+            if (this.Kind is PackIconBoxIconsKind)
+            {
+                return this.GetPackIcon<PackIconBoxIcons, PackIconBoxIconsKind>((PackIconBoxIconsKind) this.Kind);
+            }
+#endif
 #if ALL || ENTYPO
             if (this.Kind is PackIconEntypoKind)
             {
                 return this.GetPackIcon<PackIconEntypo, PackIconEntypoKind>((PackIconEntypoKind) this.Kind);
+            }
+#endif
+#if ALL || EVAICONS
+            if (this.Kind is PackIconEvaIconsKind)
+            {
+                return this.GetPackIcon<PackIconEvaIcons, PackIconEvaIconsKind>((PackIconEvaIconsKind) this.Kind);
+            }
+#endif
+#if ALL || FEATHERICONS
+            if (this.Kind is PackIconFeatherIconsKind)
+            {
+                return this.GetPackIcon<PackIconFeatherIcons, PackIconFeatherIconsKind>((PackIconFeatherIconsKind) this.Kind);
             }
 #endif
 #if ALL || FONTAWESOME
@@ -63,10 +81,28 @@ namespace MahApps.Metro.IconPacks
                 return this.GetPackIcon<PackIconFontAwesome, PackIconFontAwesomeKind>((PackIconFontAwesomeKind) this.Kind);
             }
 #endif
+#if ALL || IONICONS
+            if (this.Kind is PackIconIoniconsKind)
+            {
+                return this.GetPackIcon<PackIconIonicons, PackIconIoniconsKind>((PackIconIoniconsKind) this.Kind);
+            }
+#endif
+#if ALL || JAMICONS
+            if (this.Kind is PackIconJamIconsKind)
+            {
+                return this.GetPackIcon<PackIconJamIcons, PackIconJamIconsKind>((PackIconJamIconsKind) this.Kind);
+            }
+#endif
 #if ALL || MATERIAL
             if (this.Kind is PackIconMaterialKind)
             {
                 return this.GetPackIcon<PackIconMaterial, PackIconMaterialKind>((PackIconMaterialKind) this.Kind);
+            }
+#endif
+#if ALL || MATERIALDESIGN
+            if (this.Kind is PackIconMaterialDesignKind)
+            {
+                return this.GetPackIcon<PackIconMaterialDesign, PackIconMaterialDesignKind>((PackIconMaterialDesignKind) this.Kind);
             }
 #endif
 #if ALL || MATERIALLIGHT
@@ -93,58 +129,22 @@ namespace MahApps.Metro.IconPacks
                 return this.GetPackIcon<PackIconSimpleIcons, PackIconSimpleIconsKind>((PackIconSimpleIconsKind) this.Kind);
             }
 #endif
-#if ALL || WEATHERICONS
-            if (this.Kind is PackIconWeatherIconsKind)
-            {
-                return this.GetPackIcon<PackIconWeatherIcons, PackIconWeatherIconsKind>((PackIconWeatherIconsKind) this.Kind);
-            }
-#endif
 #if ALL || TYPICONS
             if (this.Kind is PackIconTypiconsKind)
             {
                 return this.GetPackIcon<PackIconTypicons, PackIconTypiconsKind>((PackIconTypiconsKind) this.Kind);
             }
 #endif
-#if ALL || FEATHERICONS
-            if (this.Kind is PackIconFeatherIconsKind)
-            {
-                return this.GetPackIcon<PackIconFeatherIcons, PackIconFeatherIconsKind>((PackIconFeatherIconsKind) this.Kind);
-            }
-#endif
-#if ALL || MATERIALDESIGN
-            if (this.Kind is PackIconMaterialDesignKind)
-            {
-                return this.GetPackIcon<PackIconMaterialDesign, PackIconMaterialDesignKind>((PackIconMaterialDesignKind) this.Kind);
-            }
-#endif
-#if ALL || IONICONS
-            if (this.Kind is PackIconIoniconsKind)
-            {
-                return this.GetPackIcon<PackIconIonicons, PackIconIoniconsKind>((PackIconIoniconsKind) this.Kind);
-            }
-#endif
-#if ALL || JAMICONS
-            if (this.Kind is PackIconJamIconsKind)
-            {
-                return this.GetPackIcon<PackIconJamIcons, PackIconJamIconsKind>((PackIconJamIconsKind) this.Kind);
-            }
-#endif
-#if ALL || EVAICONS
-            if (this.Kind is PackIconEvaIconsKind)
-            {
-                return this.GetPackIcon<PackIconEvaIcons, PackIconEvaIconsKind>((PackIconEvaIconsKind) this.Kind);
-            }
-#endif
-#if ALL || BOXICONS
-            if (this.Kind is PackIconBoxIconsKind)
-            {
-                return this.GetPackIcon<PackIconBoxIcons, PackIconBoxIconsKind>((PackIconBoxIconsKind) this.Kind);
-            }
-#endif
 #if ALL || UNICONS
             if (this.Kind is PackIconUniconsKind)
             {
                 return this.GetPackIcon<PackIconUnicons, PackIconUniconsKind>((PackIconUniconsKind) this.Kind);
+            }
+#endif
+#if ALL || WEATHERICONS
+            if (this.Kind is PackIconWeatherIconsKind)
+            {
+                return this.GetPackIcon<PackIconWeatherIcons, PackIconWeatherIconsKind>((PackIconWeatherIconsKind) this.Kind);
             }
 #endif
 #if ALL || ZONDICONS

--- a/src/MahApps.Metro.IconPacks/PackIconFeatherIconsDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconFeatherIconsDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconFeatherIconsDataFactory
+    public static class PackIconFeatherIconsDataFactory
     {
-        internal static IDictionary<PackIconFeatherIconsKind, string> Create()
+        public static IDictionary<PackIconFeatherIconsKind, string> Create()
         {
             return new Dictionary<PackIconFeatherIconsKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconFontAwesomeDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconFontAwesomeDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconFontAwesomeDataFactory
+    public static class PackIconFontAwesomeDataFactory
     {
-        internal static IDictionary<PackIconFontAwesomeKind, string> Create()
+        public static IDictionary<PackIconFontAwesomeKind, string> Create()
         {
             return new Dictionary<PackIconFontAwesomeKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconIoniconsDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconIoniconsDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconIoniconsDataFactory
+    public static class PackIconIoniconsDataFactory
     {
-        internal static IDictionary<PackIconIoniconsKind, string> Create()
+        public static IDictionary<PackIconIoniconsKind, string> Create()
         {
             return new Dictionary<PackIconIoniconsKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconJamIconsDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconJamIconsDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconJamIconsDataFactory
+    public static class PackIconJamIconsDataFactory
     {
-        internal static IDictionary<PackIconJamIconsKind, string> Create()
+        public static IDictionary<PackIconJamIconsKind, string> Create()
         {
             return new Dictionary<PackIconJamIconsKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconMaterialDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconMaterialDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconMaterialDataFactory
+    public static class PackIconMaterialDataFactory
     {
-        internal static IDictionary<PackIconMaterialKind, string> Create()
+        public static IDictionary<PackIconMaterialKind, string> Create()
         {
             return new Dictionary<PackIconMaterialKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconMaterialDesignDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconMaterialDesignDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconMaterialDesignDataFactory
+    public static class PackIconMaterialDesignDataFactory
     {
-        internal static IDictionary<PackIconMaterialDesignKind, string> Create()
+        public static IDictionary<PackIconMaterialDesignKind, string> Create()
         {
             return new Dictionary<PackIconMaterialDesignKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconMaterialLightDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconMaterialLightDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconMaterialLightDataFactory
+    public static class PackIconMaterialLightDataFactory
     {
-        internal static IDictionary<PackIconMaterialLightKind, string> Create()
+        public static IDictionary<PackIconMaterialLightKind, string> Create()
         {
             return new Dictionary<PackIconMaterialLightKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconModernDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconModernDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconModernDataFactory
+    public static class PackIconModernDataFactory
     {
-        internal static IDictionary<PackIconModernKind, string> Create()
+        public static IDictionary<PackIconModernKind, string> Create()
         {
             return new Dictionary<PackIconModernKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconOcticonsDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconOcticonsDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconOcticonsDataFactory
+    public static class PackIconOcticonsDataFactory
     {
-        internal static IDictionary<PackIconOcticonsKind, string> Create()
+        public static IDictionary<PackIconOcticonsKind, string> Create()
         {
             return new Dictionary<PackIconOcticonsKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconSimpleIconsDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconSimpleIconsDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconSimpleIconsDataFactory
+    public static class PackIconSimpleIconsDataFactory
     {
-        internal static IDictionary<PackIconSimpleIconsKind, string> Create()
+        public static IDictionary<PackIconSimpleIconsKind, string> Create()
         {
             return new Dictionary<PackIconSimpleIconsKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconTypiconsDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconTypiconsDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconTypiconsDataFactory
+    public static class PackIconTypiconsDataFactory
     {
-        internal static IDictionary<PackIconTypiconsKind, string> Create()
+        public static IDictionary<PackIconTypiconsKind, string> Create()
         {
             return new Dictionary<PackIconTypiconsKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconUniconsDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconUniconsDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconUniconsDataFactory
+    public static class PackIconUniconsDataFactory
     {
-        internal static IDictionary<PackIconUniconsKind, string> Create()
+        public static IDictionary<PackIconUniconsKind, string> Create()
         {
             return new Dictionary<PackIconUniconsKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconWeatherIconsDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconWeatherIconsDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconWeatherIconsDataFactory
+    public static class PackIconWeatherIconsDataFactory
     {
-        internal static IDictionary<PackIconWeatherIconsKind, string> Create()
+        public static IDictionary<PackIconWeatherIconsKind, string> Create()
         {
             return new Dictionary<PackIconWeatherIconsKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/PackIconZondiconsDataFactory.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconZondiconsDataFactory.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.IconPacks
     /// This code is auto generated. Do not amend.
     /// ******************************************
 
-    internal static class PackIconZondiconsDataFactory
+    public static class PackIconZondiconsDataFactory
     {
-        internal static IDictionary<PackIconZondiconsKind, string> Create()
+        public static IDictionary<PackIconZondiconsKind, string> Create()
         {
             return new Dictionary<PackIconZondiconsKind, string>
                    {

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/Generic.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/Generic.xaml
@@ -6,22 +6,22 @@
         <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/IconPacks.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
+    <Style TargetType="uwp:PackIconBoxIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconBoxIcons}" />
+    <Style TargetType="uwp:PackIconEntypo" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEntypo}" />
+    <Style TargetType="uwp:PackIconEvaIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEvaIcons}" />
+    <Style TargetType="uwp:PackIconFeatherIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFeatherIcons}" />
+    <Style TargetType="uwp:PackIconFontAwesome" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFontAwesome}" />
+    <Style TargetType="uwp:PackIconIonicons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconIonicons}" />
+    <Style TargetType="uwp:PackIconJamIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconJamIcons}" />
     <Style TargetType="uwp:PackIconMaterial" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterial}" />
     <Style TargetType="uwp:PackIconMaterialDesign" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterialDesign}" />
     <Style TargetType="uwp:PackIconMaterialLight" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterialLight}" />
-    <Style TargetType="uwp:PackIconFontAwesome" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFontAwesome}" />
-    <Style TargetType="uwp:PackIconOcticons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconOcticons}" />
     <Style TargetType="uwp:PackIconModern" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconModern}" />
-    <Style TargetType="uwp:PackIconEntypo" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEntypo}" />
+    <Style TargetType="uwp:PackIconOcticons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconOcticons}" />
     <Style TargetType="uwp:PackIconSimpleIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconSimpleIcons}" />
-    <Style TargetType="uwp:PackIconWeatherIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconWeatherIcons}" />
     <Style TargetType="uwp:PackIconTypicons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconTypicons}" />
-    <Style TargetType="uwp:PackIconFeatherIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFeatherIcons}" />
-    <Style TargetType="uwp:PackIconIonicons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconIonicons}" />
-    <Style TargetType="uwp:PackIconJamIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconJamIcons}" />
-    <Style TargetType="uwp:PackIconEvaIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEvaIcons}" />
-    <Style TargetType="uwp:PackIconBoxIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconBoxIcons}" />
     <Style TargetType="uwp:PackIconUnicons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconUnicons}" />
+    <Style TargetType="uwp:PackIconWeatherIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconWeatherIcons}" />
     <Style TargetType="uwp:PackIconZondicons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconZondicons}" />
 
 </ResourceDictionary>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/Generic.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/Generic.xaml
@@ -1,27 +1,2 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-<!--                     xmlns:uwp="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/IconPacks.xaml" />
-    </ResourceDictionary.MergedDictionaries>
-
-    <Style TargetType="uwp:PackIconBoxIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconBoxIcons}" />
-    <Style TargetType="uwp:PackIconEntypo" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEntypo}" />
-    <Style TargetType="uwp:PackIconEvaIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEvaIcons}" />
-    <Style TargetType="uwp:PackIconFeatherIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFeatherIcons}" />
-    <Style TargetType="uwp:PackIconFontAwesome" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFontAwesome}" />
-    <Style TargetType="uwp:PackIconIonicons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconIonicons}" />
-    <Style TargetType="uwp:PackIconJamIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconJamIcons}" />
-    <Style TargetType="uwp:PackIconMaterial" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterial}" />
-    <Style TargetType="uwp:PackIconMaterialDesign" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterialDesign}" />
-    <Style TargetType="uwp:PackIconMaterialLight" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterialLight}" />
-    <Style TargetType="uwp:PackIconModern" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconModern}" />
-    <Style TargetType="uwp:PackIconOcticons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconOcticons}" />
-    <Style TargetType="uwp:PackIconSimpleIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconSimpleIcons}" />
-    <Style TargetType="uwp:PackIconTypicons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconTypicons}" />
-    <Style TargetType="uwp:PackIconUnicons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconUnicons}" />
-    <Style TargetType="uwp:PackIconWeatherIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconWeatherIcons}" />
-    <Style TargetType="uwp:PackIconZondicons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconZondicons}" />
- -->
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 </ResourceDictionary>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/Generic.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/Generic.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:uwp="using:MahApps.Metro.IconPacks">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<!--                     xmlns:uwp="using:MahApps.Metro.IconPacks">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/IconPacks.xaml" />
@@ -23,5 +23,5 @@
     <Style TargetType="uwp:PackIconUnicons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconUnicons}" />
     <Style TargetType="uwp:PackIconWeatherIcons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconWeatherIcons}" />
     <Style TargetType="uwp:PackIconZondicons" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconZondicons}" />
-
+ -->
 </ResourceDictionary>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/IconPacks.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/IconPacks.xaml
@@ -2,23 +2,23 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconMaterial.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconMaterialDesign.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconMaterialLight.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconFontAwesome.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconOcticons.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconModern.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconEntypo.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconSimpleIcons.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconWeatherIcons.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconTypicons.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconFeatherIcons.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconIonicons.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconJamIcons.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconEvaIcons.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconBoxIcons.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconUnicons.xaml" />
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks/Themes/PackIconZondicons.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.BoxIcons/Themes/PackIconBoxIcons.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Entypo/Themes/PackIconEntypo.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.EvaIcons/Themes/PackIconEvaIcons.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.FeatherIcons/Themes/PackIconFeatherIcons.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.FontAwesome/Themes/PackIconFontAwesome.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Ionicons/Themes/PackIconIonicons.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.JamIcons/Themes/PackIconJamIcons.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Material/Themes/PackIconMaterial.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.MaterialDesign/Themes/PackIconMaterialDesign.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.MaterialLight/Themes/PackIconMaterialLight.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Modern/Themes/PackIconModern.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Octicons/Themes/PackIconOcticons.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.SimpleIcons/Themes/PackIconSimpleIcons.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Typicons/Themes/PackIconTypicons.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Unicons/Themes/PackIconUnicons.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.WeatherIcons/Themes/PackIconWeatherIcons.xaml" />
+        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Zondicons/Themes/PackIconZondicons.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/IconPacks.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/IconPacks.xaml
@@ -1,5 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.BoxIcons/Themes/PackIconBoxIcons.xaml" />

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconBoxIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconBoxIcons.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconBoxIcons" TargetType="iconPacks:PackIconBoxIcons">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           RenderTransformOrigin="0.5 0.5"
                           UseLayoutRounding="False">
                         <Path.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconEntypo.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconEntypo.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconEntypo" TargetType="iconPacks:PackIconEntypo">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           UseLayoutRounding="False" />
                 </Viewbox>
             </Grid>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconEvaIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconEvaIcons.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconEvaIcons" TargetType="iconPacks:PackIconEvaIcons">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           RenderTransformOrigin="0.5 0.5"
                           UseLayoutRounding="False">
                         <Path.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconFeatherIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconFeatherIcons.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconFeatherIcons" TargetType="iconPacks:PackIconFeatherIcons">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -33,7 +30,7 @@
                           Width="24"
                           Height="24"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           UseLayoutRounding="False" />
                 </Viewbox>
             </Grid>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconFontAwesome.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconFontAwesome.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconFontAwesome" TargetType="iconPacks:PackIconFontAwesome">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           RenderTransformOrigin="0.5 0.5"
                           UseLayoutRounding="False" />
                 </Viewbox>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconIonicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconIonicons.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconIonicons" TargetType="iconPacks:PackIconIonicons">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           UseLayoutRounding="False" />
                 </Viewbox>
             </Grid>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconJamIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconJamIcons.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconJamIcons" TargetType="iconPacks:PackIconJamIcons">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           RenderTransformOrigin="0.5 0.5"
                           UseLayoutRounding="False">
                         <Path.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterial.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterial.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconMaterial" TargetType="iconPacks:PackIconMaterial">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           UseLayoutRounding="False" />
                 </Viewbox>
             </Grid>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterialDesign.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterialDesign.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconMaterialDesign" TargetType="iconPacks:PackIconMaterialDesign">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           RenderTransformOrigin="0.5 0.5"
                           UseLayoutRounding="False">
                         <Path.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterialLight.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconMaterialLight.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconMaterialLight" TargetType="iconPacks:PackIconMaterialLight">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           UseLayoutRounding="False" />
                 </Viewbox>
             </Grid>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconModern.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconModern.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconModern" TargetType="iconPacks:PackIconModern">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           UseLayoutRounding="False" />
                 </Viewbox>
             </Grid>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconOcticons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconOcticons.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconOcticons" TargetType="iconPacks:PackIconOcticons">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           UseLayoutRounding="False" />
                 </Viewbox>
             </Grid>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconSimpleIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconSimpleIcons.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconSimpleIcons" TargetType="iconPacks:PackIconSimpleIcons">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           UseLayoutRounding="False" />
                 </Viewbox>
             </Grid>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconTypicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconTypicons.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconTypicons" TargetType="iconPacks:PackIconTypicons">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           RenderTransformOrigin="0.5 0.5"
                           UseLayoutRounding="False">
                         <Path.RenderTransform>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconUnicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconUnicons.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconUnicons" TargetType="iconPacks:PackIconUnicons">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           UseLayoutRounding="False" />
                 </Viewbox>
             </Grid>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconWeatherIcons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconWeatherIcons.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconWeatherIcons" TargetType="iconPacks:PackIconWeatherIcons">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           UseLayoutRounding="False" />
                 </Viewbox>
             </Grid>

--- a/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconZondicons.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/UAP/PackIconZondicons.xaml
@@ -1,10 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="using:MahApps.Metro.IconPacks">
-
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx:///MahApps.Metro.IconPacks.Core/Converter/Converters.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:iconPacks="using:MahApps.Metro.IconPacks"
+                    xmlns:converter="using:MahApps.Metro.IconPacks.Converter">
 
     <ControlTemplate x:Key="MahApps.Templates.PackIconZondicons" TargetType="iconPacks:PackIconZondicons">
         <Grid>
@@ -17,8 +14,8 @@
                 <Grid.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform x:Name="FlipTransform"
-                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleXValueConverter}}"
-                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={StaticResource FlipToScaleYValueConverter}}" />
+                                        ScaleX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleXValueConverter}}"
+                                        ScaleY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Flip, Mode=OneWay, Converter={converter:FlipToScaleYValueConverter}}" />
                         <RotateTransform x:Name="RotationTransform"
                                          Angle="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RotationAngle, Mode=OneWay}" />
                         <RotateTransform x:Name="SpinTransform" />
@@ -27,7 +24,7 @@
                 <Viewbox Margin="{TemplateBinding Padding}">
                     <Path Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
-                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Converter={StaticResource NullToUnsetValueConverter}}"
+                          Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           UseLayoutRounding="False" />
                 </Viewbox>
             </Grid>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/Generic.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/Generic.xaml
@@ -1,31 +1,11 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="clr-namespace:MahApps.Metro.IconPacks"
-                    xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks">
+                    xmlns:local="clr-namespace:MahApps.Metro.IconPacks">
 
     <ResourceDictionary.MergedDictionaries>
-        <!-- <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/IconPacks.xaml" /> -->
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconControl.xaml" />
     </ResourceDictionary.MergedDictionaries>
-<!-- 
-    <Style TargetType="{x:Type iconPacks:PackIconBoxIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconBoxIcons}" />
-    <Style TargetType="{x:Type iconPacks:PackIconEntypo}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEntypo}" />
-    <Style TargetType="{x:Type iconPacks:PackIconEvaIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEvaIcons}" />
-    <Style TargetType="{x:Type iconPacks:PackIconFeatherIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFeatherIcons}" />
-    <Style TargetType="{x:Type iconPacks:PackIconFontAwesome}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFontAwesome}" />
-    <Style TargetType="{x:Type iconPacks:PackIconIonicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconIonicons}" />
-    <Style TargetType="{x:Type iconPacks:PackIconJamIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconJamIcons}" />
-    <Style TargetType="{x:Type iconPacks:PackIconMaterialDesign}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterialDesign}" />
-    <Style TargetType="{x:Type iconPacks:PackIconMaterialLight}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterialLight}" />
-    <Style TargetType="{x:Type iconPacks:PackIconMaterial}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterial}" />
-    <Style TargetType="{x:Type iconPacks:PackIconModern}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconModern}" />
-    <Style TargetType="{x:Type iconPacks:PackIconOcticons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconOcticons}" />
-    <Style TargetType="{x:Type iconPacks:PackIconSimpleIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconSimpleIcons}" />
-    <Style TargetType="{x:Type iconPacks:PackIconTypicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconTypicons}" />
-    <Style TargetType="{x:Type iconPacks:PackIconUnicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconUnicons}" />
-    <Style TargetType="{x:Type iconPacks:PackIconWeatherIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconWeatherIcons}" />
-    <Style TargetType="{x:Type iconPacks:PackIconZondicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconZondicons}" />
- -->
+
     <Style TargetType="{x:Type local:PackIconControl}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconControl}" />
 
 </ResourceDictionary>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/Generic.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/Generic.xaml
@@ -4,9 +4,10 @@
                     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks">
 
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/IconPacks.xaml" />
+        <!-- <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/IconPacks.xaml" /> -->
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconControl.xaml" />
     </ResourceDictionary.MergedDictionaries>
-
+<!-- 
     <Style TargetType="{x:Type iconPacks:PackIconBoxIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconBoxIcons}" />
     <Style TargetType="{x:Type iconPacks:PackIconEntypo}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEntypo}" />
     <Style TargetType="{x:Type iconPacks:PackIconEvaIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEvaIcons}" />
@@ -24,7 +25,7 @@
     <Style TargetType="{x:Type iconPacks:PackIconUnicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconUnicons}" />
     <Style TargetType="{x:Type iconPacks:PackIconWeatherIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconWeatherIcons}" />
     <Style TargetType="{x:Type iconPacks:PackIconZondicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconZondicons}" />
-
+ -->
     <Style TargetType="{x:Type local:PackIconControl}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconControl}" />
 
 </ResourceDictionary>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/Generic.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/Generic.xaml
@@ -1,28 +1,30 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="clr-namespace:MahApps.Metro.IconPacks">
+                    xmlns:local="clr-namespace:MahApps.Metro.IconPacks"
+                    xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/IconPacks.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style TargetType="{x:Type local:PackIconMaterial}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterial}" />
-    <Style TargetType="{x:Type local:PackIconMaterialDesign}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterialDesign}" />
-    <Style TargetType="{x:Type local:PackIconMaterialLight}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterialLight}" />
-    <Style TargetType="{x:Type local:PackIconFontAwesome}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFontAwesome}" />
-    <Style TargetType="{x:Type local:PackIconOcticons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconOcticons}" />
-    <Style TargetType="{x:Type local:PackIconModern}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconModern}" />
-    <Style TargetType="{x:Type local:PackIconEntypo}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEntypo}" />
-    <Style TargetType="{x:Type local:PackIconSimpleIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconSimpleIcons}" />
-    <Style TargetType="{x:Type local:PackIconWeatherIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconWeatherIcons}" />
-    <Style TargetType="{x:Type local:PackIconTypicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconTypicons}" />
-    <Style TargetType="{x:Type local:PackIconFeatherIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFeatherIcons}" />
-    <Style TargetType="{x:Type local:PackIconIonicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconIonicons}" />
-    <Style TargetType="{x:Type local:PackIconJamIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconJamIcons}" />
-    <Style TargetType="{x:Type local:PackIconEvaIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEvaIcons}" />
-    <Style TargetType="{x:Type local:PackIconBoxIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconBoxIcons}" />
-    <Style TargetType="{x:Type local:PackIconUnicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconUnicons}" />
-    <Style TargetType="{x:Type local:PackIconZondicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconZondicons}" />
+    <Style TargetType="{x:Type iconPacks:PackIconBoxIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconBoxIcons}" />
+    <Style TargetType="{x:Type iconPacks:PackIconEntypo}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEntypo}" />
+    <Style TargetType="{x:Type iconPacks:PackIconEvaIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconEvaIcons}" />
+    <Style TargetType="{x:Type iconPacks:PackIconFeatherIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFeatherIcons}" />
+    <Style TargetType="{x:Type iconPacks:PackIconFontAwesome}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconFontAwesome}" />
+    <Style TargetType="{x:Type iconPacks:PackIconIonicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconIonicons}" />
+    <Style TargetType="{x:Type iconPacks:PackIconJamIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconJamIcons}" />
+    <Style TargetType="{x:Type iconPacks:PackIconMaterialDesign}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterialDesign}" />
+    <Style TargetType="{x:Type iconPacks:PackIconMaterialLight}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterialLight}" />
+    <Style TargetType="{x:Type iconPacks:PackIconMaterial}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconMaterial}" />
+    <Style TargetType="{x:Type iconPacks:PackIconModern}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconModern}" />
+    <Style TargetType="{x:Type iconPacks:PackIconOcticons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconOcticons}" />
+    <Style TargetType="{x:Type iconPacks:PackIconSimpleIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconSimpleIcons}" />
+    <Style TargetType="{x:Type iconPacks:PackIconTypicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconTypicons}" />
+    <Style TargetType="{x:Type iconPacks:PackIconUnicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconUnicons}" />
+    <Style TargetType="{x:Type iconPacks:PackIconWeatherIcons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconWeatherIcons}" />
+    <Style TargetType="{x:Type iconPacks:PackIconZondicons}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconZondicons}" />
+
     <Style TargetType="{x:Type local:PackIconControl}" BasedOn="{StaticResource MahApps.Metro.Styles.PackIconControl}" />
 
 </ResourceDictionary>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/IconPacks.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/IconPacks.xaml
@@ -2,23 +2,24 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconMaterial.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconMaterialDesign.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconMaterialLight.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconFontAwesome.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconOcticons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconModern.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconEntypo.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconSimpleIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconWeatherIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconTypicons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconFeatherIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconIonicons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconJamIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconEvaIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconBoxIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconUnicons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconZondicons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.BoxIcons/Themes/PackIconBoxIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Entypo/Themes/PackIconEntypo.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.EvaIcons/Themes/PackIconEvaIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.FeatherIcons/Themes/PackIconFeatherIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.FontAwesome/Themes/PackIconFontAwesome.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Ionicons/Themes/PackIconIonicons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.JamIcons/Themes/PackIconJamIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Material/Themes/PackIconMaterial.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.MaterialDesign/Themes/PackIconMaterialDesign.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.MaterialLight/Themes/PackIconMaterialLight.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Modern/Themes/PackIconModern.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Octicons/Themes/PackIconOcticons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.SimpleIcons/Themes/PackIconSimpleIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Typicons/Themes/PackIconTypicons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Unicons/Themes/PackIconUnicons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.WeatherIcons/Themes/PackIconWeatherIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Zondicons/Themes/PackIconZondicons.xaml" />
+
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconControl.xaml" />
     </ResourceDictionary.MergedDictionaries>
 

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/IconPacks.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/IconPacks.xaml
@@ -1,24 +1,23 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.BoxIcons/Themes/PackIconBoxIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Entypo/Themes/PackIconEntypo.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.EvaIcons/Themes/PackIconEvaIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.FeatherIcons/Themes/PackIconFeatherIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.FontAwesome/Themes/PackIconFontAwesome.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Ionicons/Themes/PackIconIonicons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.JamIcons/Themes/PackIconJamIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Material/Themes/PackIconMaterial.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.MaterialDesign/Themes/PackIconMaterialDesign.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.MaterialLight/Themes/PackIconMaterialLight.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Modern/Themes/PackIconModern.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Octicons/Themes/PackIconOcticons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.SimpleIcons/Themes/PackIconSimpleIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Typicons/Themes/PackIconTypicons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Unicons/Themes/PackIconUnicons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.WeatherIcons/Themes/PackIconWeatherIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Zondicons/Themes/PackIconZondicons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.BoxIcons;component/Themes/PackIconBoxIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Entypo;component/Themes/PackIconEntypo.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.EvaIcons;component/Themes/PackIconEvaIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.FeatherIcons;component/Themes/PackIconFeatherIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.FontAwesome;component/Themes/PackIconFontAwesome.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Ionicons;component/Themes/PackIconIonicons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.JamIcons;component/Themes/PackIconJamIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Material;component/Themes/PackIconMaterial.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.MaterialDesign;component/Themes/PackIconMaterialDesign.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.MaterialLight;component/Themes/PackIconMaterialLight.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Modern;component/Themes/PackIconModern.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Octicons;component/Themes/PackIconOcticons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.SimpleIcons;component/Themes/PackIconSimpleIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Typicons;component/Themes/PackIconTypicons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Unicons;component/Themes/PackIconUnicons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.WeatherIcons;component/Themes/PackIconWeatherIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Zondicons;component/Themes/PackIconZondicons.xaml" />
 
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks;component/Themes/PackIconControl.xaml" />
     </ResourceDictionary.MergedDictionaries>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconControl.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconControl.xaml
@@ -1,10 +1,10 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacksProject="clr-namespace:MahApps.Metro.IconPacks"
+                    xmlns:local="clr-namespace:MahApps.Metro.IconPacks"
                     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
                     xmlns:converter="clr-namespace:MahApps.Metro.IconPacks.Converter;assembly=MahApps.Metro.IconPacks.Core">
 
-    <ControlTemplate x:Key="MahApps.Templates.PackIconControl" TargetType="{x:Type iconPacksProject:PackIconControl}">
+    <ControlTemplate x:Key="MahApps.Templates.PackIconControl" TargetType="{x:Type local:PackIconControl}">
         <Grid>
             <Border Background="{TemplateBinding Background}"
                     BorderBrush="{TemplateBinding BorderBrush}"
@@ -34,7 +34,7 @@
         </Grid>
     </ControlTemplate>
 
-    <Style x:Key="MahApps.Metro.Styles.PackIconControl" TargetType="{x:Type iconPacksProject:PackIconControl}">
+    <Style x:Key="MahApps.Metro.Styles.PackIconControl" TargetType="{x:Type local:PackIconControl}">
         <Setter Property="Height" Value="16" />
         <Setter Property="Width" Value="16" />
         <Setter Property="Padding" Value="0" />

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconControl.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconControl.xaml
@@ -4,6 +4,26 @@
                     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
                     xmlns:converter="clr-namespace:MahApps.Metro.IconPacks.Converter;assembly=MahApps.Metro.IconPacks.Core">
 
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.BoxIcons;component/Themes/PackIconBoxIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Entypo;component/Themes/PackIconEntypo.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.EvaIcons;component/Themes/PackIconEvaIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.FeatherIcons;component/Themes/PackIconFeatherIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.FontAwesome;component/Themes/PackIconFontAwesome.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Ionicons;component/Themes/PackIconIonicons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.JamIcons;component/Themes/PackIconJamIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Material;component/Themes/PackIconMaterial.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.MaterialDesign;component/Themes/PackIconMaterialDesign.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.MaterialLight;component/Themes/PackIconMaterialLight.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Modern;component/Themes/PackIconModern.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Octicons;component/Themes/PackIconOcticons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.SimpleIcons;component/Themes/PackIconSimpleIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Typicons;component/Themes/PackIconTypicons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Unicons;component/Themes/PackIconUnicons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.WeatherIcons;component/Themes/PackIconWeatherIcons.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Zondicons;component/Themes/PackIconZondicons.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
     <ControlTemplate x:Key="MahApps.Templates.PackIconControl" TargetType="{x:Type local:PackIconControl}">
         <Grid>
             <Border Background="{TemplateBinding Background}"
@@ -47,55 +67,55 @@
         <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconControl}" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconBoxIconsKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconBoxIcons}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconBoxIcons}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconEntypoKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconEntypo}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconEntypo}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconEvaIconsKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconEvaIcons}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconEvaIcons}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconFeatherIconsKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconFeatherIcons}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconFeatherIcons}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconFontAwesomeKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconFontAwesome}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconFontAwesome}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconIoniconsKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconIonicons}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconIonicons}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconJamIconsKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconJamIcons}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconJamIcons}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconMaterialKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconMaterial}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconMaterial}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconMaterialDesignKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconMaterialDesign}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconMaterialDesign}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconMaterialLightKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconMaterialLight}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconMaterialLight}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconModernKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconModern}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconModern}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconOcticonsKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconOcticons}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconOcticons}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconSimpleIconsKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconSimpleIcons}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconSimpleIcons}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconTypiconsKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconTypicons}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconTypicons}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconUniconsKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconUnicons}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconUnicons}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconWeatherIconsKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconWeatherIcons}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconWeatherIcons}" />
             </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconZondiconsKind}">
-                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconZondicons}" />
+                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconZondicons}" />
             </DataTrigger>
         </Style.Triggers>
     </Style>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconControl.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconControl.xaml
@@ -4,26 +4,6 @@
                     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
                     xmlns:converter="clr-namespace:MahApps.Metro.IconPacks.Converter;assembly=MahApps.Metro.IconPacks.Core">
 
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.BoxIcons;component/Themes/PackIconBoxIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Entypo;component/Themes/PackIconEntypo.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.EvaIcons;component/Themes/PackIconEvaIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.FeatherIcons;component/Themes/PackIconFeatherIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.FontAwesome;component/Themes/PackIconFontAwesome.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Ionicons;component/Themes/PackIconIonicons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.JamIcons;component/Themes/PackIconJamIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Material;component/Themes/PackIconMaterial.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.MaterialDesign;component/Themes/PackIconMaterialDesign.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.MaterialLight;component/Themes/PackIconMaterialLight.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Modern;component/Themes/PackIconModern.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Octicons;component/Themes/PackIconOcticons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.SimpleIcons;component/Themes/PackIconSimpleIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Typicons;component/Themes/PackIconTypicons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Unicons;component/Themes/PackIconUnicons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.WeatherIcons;component/Themes/PackIconWeatherIcons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.IconPacks.Zondicons;component/Themes/PackIconZondicons.xaml" />
-    </ResourceDictionary.MergedDictionaries>
-
     <ControlTemplate x:Key="MahApps.Templates.PackIconControl" TargetType="{x:Type local:PackIconControl}">
         <Grid>
             <Border Background="{TemplateBinding Background}"
@@ -44,7 +24,8 @@
                     </TransformGroup>
                 </Grid.RenderTransform>
                 <Viewbox Margin="{TemplateBinding Padding}">
-                    <Path Fill="{TemplateBinding Foreground}"
+                    <Path x:Name="PART_IconPath"
+                          Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
                           Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converter:NullToUnsetValueConverter}}"
                           SnapsToDevicePixels="False"
@@ -52,6 +33,53 @@
                 </Viewbox>
             </Grid>
         </Grid>
+        <ControlTemplate.Triggers>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind, Converter={converter:DataTypeValueConverter}}" Value="{x:Type iconPacks:PackIconBoxIconsKind}">
+                <Setter TargetName="PART_IconPath" Property="LayoutTransform">
+                    <Setter.Value>
+                        <ScaleTransform ScaleY="-1" />
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind, Converter={converter:DataTypeValueConverter}}" Value="{x:Type iconPacks:PackIconEvaIconsKind}">
+                <Setter TargetName="PART_IconPath" Property="LayoutTransform">
+                    <Setter.Value>
+                        <ScaleTransform ScaleY="-1" />
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind, Converter={converter:DataTypeValueConverter}}" Value="{x:Type iconPacks:PackIconFeatherIconsKind}">
+                <Setter TargetName="PART_IconPath" Property="Fill" Value="{x:Null}" />
+                <Setter TargetName="PART_IconPath" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground, Mode=OneWay}" />
+                <Setter TargetName="PART_IconPath" Property="StrokeThickness" Value="2" />
+                <Setter TargetName="PART_IconPath" Property="StrokeStartLineCap" Value="Round" />
+                <Setter TargetName="PART_IconPath" Property="StrokeEndLineCap" Value="Round" />
+                <Setter TargetName="PART_IconPath" Property="StrokeLineJoin" Value="Round" />
+                <Setter TargetName="PART_IconPath" Property="Width" Value="24" />
+                <Setter TargetName="PART_IconPath" Property="Height" Value="24" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind, Converter={converter:DataTypeValueConverter}}" Value="{x:Type iconPacks:PackIconJamIconsKind}">
+                <Setter TargetName="PART_IconPath" Property="LayoutTransform">
+                    <Setter.Value>
+                        <ScaleTransform ScaleY="-1" />
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind, Converter={converter:DataTypeValueConverter}}" Value="{x:Type iconPacks:PackIconMaterialDesignKind}">
+                <Setter TargetName="PART_IconPath" Property="LayoutTransform">
+                    <Setter.Value>
+                        <ScaleTransform ScaleY="-1" />
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind, Converter={converter:DataTypeValueConverter}}" Value="{x:Type iconPacks:PackIconTypiconsKind}">
+                <Setter TargetName="PART_IconPath" Property="LayoutTransform">
+                    <Setter.Value>
+                        <ScaleTransform ScaleY="-1" />
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <Style x:Key="MahApps.Metro.Styles.PackIconControl" TargetType="{x:Type local:PackIconControl}">
@@ -65,59 +93,6 @@
         <Setter Property="SnapsToDevicePixels" Value="False" />
         <Setter Property="UseLayoutRounding" Value="False" />
         <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconControl}" />
-        <Style.Triggers>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconBoxIconsKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconBoxIcons}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconEntypoKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconEntypo}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconEvaIconsKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconEvaIcons}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconFeatherIconsKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconFeatherIcons}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconFontAwesomeKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconFontAwesome}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconIoniconsKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconIonicons}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconJamIconsKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconJamIcons}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconMaterialKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconMaterial}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconMaterialDesignKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconMaterialDesign}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconMaterialLightKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconMaterialLight}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconModernKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconModern}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconOcticonsKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconOcticons}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconSimpleIconsKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconSimpleIcons}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconTypiconsKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconTypicons}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconUniconsKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconUnicons}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconWeatherIconsKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconWeatherIcons}" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconZondiconsKind}">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconZondicons}" />
-            </DataTrigger>
-        </Style.Triggers>
     </Style>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconControl.xaml
+++ b/src/MahApps.Metro.IconPacks/Themes/WPF/PackIconControl.xaml
@@ -1,9 +1,10 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:iconPacks="clr-namespace:MahApps.Metro.IconPacks"
+                    xmlns:iconPacksProject="clr-namespace:MahApps.Metro.IconPacks"
+                    xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
                     xmlns:converter="clr-namespace:MahApps.Metro.IconPacks.Converter;assembly=MahApps.Metro.IconPacks.Core">
 
-    <ControlTemplate x:Key="MahApps.Templates.PackIconControl" TargetType="{x:Type iconPacks:PackIconControl}">
+    <ControlTemplate x:Key="MahApps.Templates.PackIconControl" TargetType="{x:Type iconPacksProject:PackIconControl}">
         <Grid>
             <Border Background="{TemplateBinding Background}"
                     BorderBrush="{TemplateBinding BorderBrush}"
@@ -33,7 +34,7 @@
         </Grid>
     </ControlTemplate>
 
-    <Style x:Key="MahApps.Metro.Styles.PackIconControl" TargetType="{x:Type iconPacks:PackIconControl}">
+    <Style x:Key="MahApps.Metro.Styles.PackIconControl" TargetType="{x:Type iconPacksProject:PackIconControl}">
         <Setter Property="Height" Value="16" />
         <Setter Property="Width" Value="16" />
         <Setter Property="Padding" Value="0" />
@@ -45,6 +46,9 @@
         <Setter Property="UseLayoutRounding" Value="False" />
         <Setter Property="Template" Value="{StaticResource MahApps.Templates.PackIconControl}" />
         <Style.Triggers>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconBoxIconsKind}">
+                <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconBoxIcons}" />
+            </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Kind}" Value="{x:Type iconPacks:PackIconEntypoKind}">
                 <Setter Property="Template" Value="{DynamicResource MahApps.Templates.PackIconEntypo}" />
             </DataTrigger>


### PR DESCRIPTION
Changes of this PR

- Use each IcanPacks as ProjectReference in the main IconPacks package (project)
- Fix usage of PackIconBoxIcons in PackIconControl (WPF)
- Fix getting correct template for PackIconControl
- Use the MarkupConverter (MarkupExtension) now also for UAP