### PR TITLE
Changing classes to no longer derive from a generic class

### DIFF
--- a/src/MahApps.Metro.IconPacks.Core/PackIconBase.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PackIconBase.cs
@@ -1,106 +1,14 @@
-using System;
-using System.Collections.Generic;
 #if (NETFX_CORE || WINDOWS_UWP)
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Media;
 #else
-using System.ComponentModel;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 #endif
 
 namespace MahApps.Metro.IconPacks
 {
     public abstract class PackIconBase : Control
     {
-        internal abstract void UpdateData();
-    }
-
-    /// <summary>
-    /// Base class for creating an icon control for icon packs.
-    /// </summary>
-    /// <typeparam name="TKind"></typeparam>
-    public abstract class PackIconBase<TKind> : PackIconBase
-    {
-        private static Lazy<IDictionary<TKind, string>> _dataIndex;
-
-        /// <param name="dataIndexFactory">
-        /// Inheritors should provide a factory for setting up the path data index (per icon kind).
-        /// The factory will only be utilized once, across all closed instances (first instantiation wins).
-        /// </param>
-        protected PackIconBase(Func<IDictionary<TKind, string>> dataIndexFactory)
-        {
-            if (dataIndexFactory == null) throw new ArgumentNullException(nameof(dataIndexFactory));
-
-            if (_dataIndex == null)
-                _dataIndex = new Lazy<IDictionary<TKind, string>>(dataIndexFactory);
-        }
-
-        public static readonly DependencyProperty KindProperty
-            = DependencyProperty.Register(nameof(Kind), typeof(TKind), typeof(PackIconBase<TKind>), new PropertyMetadata(default(TKind), KindPropertyChangedCallback));
-
-        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-        {
-            ((PackIconBase)dependencyObject).UpdateData();
-        }
-
-        /// <summary>
-        /// Gets or sets the icon to display.
-        /// </summary>
-        public TKind Kind
-        {
-            get { return (TKind)GetValue(KindProperty); }
-            set { SetValue(KindProperty, value); }
-        }
-
-#if (NETFX_CORE || WINDOWS_UWP)
-        private static readonly DependencyProperty DataProperty
-            = DependencyProperty.Register(nameof(Data), typeof(string), typeof(PackIconBase<TKind>), new PropertyMetadata(""));
-
-        /// <summary>
-        /// Gets the icon path data for the current <see cref="Kind"/>.
-        /// </summary>
-        public string Data
-        {
-            get { return (string)GetValue(DataProperty); }
-            private set { SetValue(DataProperty, value); }
-        }
-#else
-        private static readonly DependencyPropertyKey DataPropertyKey
-            = DependencyProperty.RegisterReadOnly(nameof(Data), typeof(string), typeof(PackIconBase<TKind>), new PropertyMetadata(""));
-
-        // ReSharper disable once StaticMemberInGenericType
-        public static readonly DependencyProperty DataProperty = DataPropertyKey.DependencyProperty;
-
-        /// <summary>
-        /// Gets the icon path data for the current <see cref="Kind"/>.
-        /// </summary>
-        [TypeConverter(typeof(GeometryConverter))]
-        public string Data
-        {
-            get { return (string)GetValue(DataProperty); }
-            private set { SetValue(DataPropertyKey, value); }
-        }
-#endif
-
-#if (NETFX_CORE || WINDOWS_UWP)
-        protected override void OnApplyTemplate()
-#else
-        public override void OnApplyTemplate()
-#endif
-        {
-            base.OnApplyTemplate();
-
-            UpdateData();
-        }
-
-        internal override void UpdateData()
-        {
-            string data = null;
-            _dataIndex.Value?.TryGetValue(Kind, out data);
-            this.Data = data;
-        }
+        protected internal abstract void SetKind<TKind>(TKind iconKind);
+        protected abstract void UpdateData();
     }
 }

--- a/src/MahApps.Metro.IconPacks.Core/PackIconControlBase.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PackIconControlBase.cs
@@ -1,11 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 #if NETFX_CORE || WINDOWS_UWP
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 #else
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -14,18 +14,16 @@ using System.Windows.Media.Animation;
 namespace MahApps.Metro.IconPacks
 {
     /// <summary>
-    /// Class PackIconControl which is the base class for any PackIcon control.
+    /// Class PackIconControlBase which is the base class for any PackIcon control.
     /// </summary>
-    /// <typeparam name="TKind">The type of the enum kind.</typeparam>
-    /// <seealso cref="PackIconBase{TKind}" />
-    public abstract class PackIconControl<TKind> : PackIconBase<TKind>
+    public abstract class PackIconControlBase : PackIconBase
     {
 
 #if NETFX_CORE || WINDOWS_UWP
         private long _opacityRegisterToken;
         private long _visibilityRegisterToken;
 
-        public PackIconControl(Func<IDictionary<TKind, string>> dataIndexFactory) : base(dataIndexFactory)
+        public PackIconControlBase()
         {
             this.Loaded += (sender, args) =>
             {
@@ -41,7 +39,7 @@ namespace MahApps.Metro.IconPacks
 
         private void CoerceSpinProperty(DependencyObject sender, DependencyProperty dp)
         {
-            var packIcon = sender as PackIconControl<TKind>;
+            var packIcon = sender as PackIconControlBase;
             if (packIcon != null && (dp == OpacityProperty || dp == VisibilityProperty))
             {
                 var spin = this.Spin && packIcon.Visibility == Visibility.Visible && packIcon.SpinDuration > 0 && packIcon.Opacity > 0;
@@ -49,14 +47,40 @@ namespace MahApps.Metro.IconPacks
             }
         }
 #else
-        static PackIconControl()
+        static PackIconControlBase()
         {
-            OpacityProperty.OverrideMetadata(typeof(PackIconControl<TKind>), new UIPropertyMetadata(1d, (d, e) => { d.CoerceValue(SpinProperty); }));
-            VisibilityProperty.OverrideMetadata(typeof(PackIconControl<TKind>), new UIPropertyMetadata(Visibility.Visible, (d, e) => { d.CoerceValue(SpinProperty); }));
+            OpacityProperty.OverrideMetadata(typeof(PackIconControlBase), new UIPropertyMetadata(1d, (d, e) => { d.CoerceValue(SpinProperty); }));
+            VisibilityProperty.OverrideMetadata(typeof(PackIconControlBase), new UIPropertyMetadata(Visibility.Visible, (d, e) => { d.CoerceValue(SpinProperty); }));
         }
+#endif
 
-        protected PackIconControl(Func<IDictionary<TKind, string>> dataIndexFactory) : base(dataIndexFactory)
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected static readonly DependencyProperty DataProperty
+            = DependencyProperty.Register(nameof(Data), typeof(string), typeof(PackIconBase), new PropertyMetadata(""));
+
+        /// <summary>
+        /// Gets the path data for the current icon kind.
+        /// </summary>
+        public string Data
         {
+            get { return (string)GetValue(DataProperty); }
+            protected set { SetValue(DataProperty, value); }
+        }
+#else
+        private static readonly DependencyPropertyKey DataPropertyKey
+            = DependencyProperty.RegisterReadOnly(nameof(Data), typeof(string), typeof(PackIconBase), new PropertyMetadata(""));
+
+        // ReSharper disable once StaticMemberInGenericType
+        public static readonly DependencyProperty DataProperty = DataPropertyKey.DependencyProperty;
+
+        /// <summary>
+        /// Gets the path data for the current icon kind.
+        /// </summary>
+        [TypeConverter(typeof(GeometryConverter))]
+        public string Data
+        {
+            get { return (string)GetValue(DataProperty); }
+            protected set { SetValue(DataPropertyKey, value); }
         }
 #endif
 
@@ -64,7 +88,11 @@ namespace MahApps.Metro.IconPacks
         protected override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
+
+            this.UpdateData();
+
             this.CoerceSpinProperty(this, SpinProperty);
+
             if (this.Spin)
             {
                 this.StopSpinAnimation();
@@ -75,7 +103,11 @@ namespace MahApps.Metro.IconPacks
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
+
+            this.UpdateData();
+
             this.CoerceValue(SpinProperty);
+
             if (this.Spin)
             {
                 this.StopSpinAnimation();
@@ -91,7 +123,7 @@ namespace MahApps.Metro.IconPacks
             = DependencyProperty.Register(
                 nameof(Flip),
                 typeof(PackIconFlipOrientation),
-                typeof(PackIconControl<TKind>),
+                typeof(PackIconControlBase),
                 new PropertyMetadata(PackIconFlipOrientation.Normal));
 
         /// <summary>
@@ -110,7 +142,7 @@ namespace MahApps.Metro.IconPacks
             = DependencyProperty.Register(
                 nameof(RotationAngle),
                 typeof(double),
-                typeof(PackIconControl<TKind>),
+                typeof(PackIconControlBase),
 #if NETFX_CORE || WINDOWS_UWP
                 new PropertyMetadata(0d));
 #else
@@ -140,7 +172,7 @@ namespace MahApps.Metro.IconPacks
             = DependencyProperty.Register(
                 nameof(Spin),
                 typeof(bool),
-                typeof(PackIconControl<TKind>),
+                typeof(PackIconControlBase),
 #if NETFX_CORE || WINDOWS_UWP
                 new PropertyMetadata(default(bool), SpinPropertyChangedCallback));
 #else
@@ -148,7 +180,7 @@ namespace MahApps.Metro.IconPacks
 
         private static object SpinPropertyCoerceValueCallback(DependencyObject dependencyObject, object value)
         {
-            var packIcon = dependencyObject as PackIconControl<TKind>;
+            var packIcon = dependencyObject as PackIconControlBase;
             if (packIcon != null && (!packIcon.IsVisible || packIcon.Opacity <= 0 || packIcon.SpinDuration <= 0.0))
             {
                 return false;
@@ -159,7 +191,7 @@ namespace MahApps.Metro.IconPacks
 
         private static void SpinPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
-            var packIcon = dependencyObject as PackIconControl<TKind>;
+            var packIcon = dependencyObject as PackIconControlBase;
             if (packIcon != null && e.OldValue != e.NewValue && e.NewValue is bool)
             {
                 packIcon.ToggleSpinAnimation((bool)e.NewValue);
@@ -250,7 +282,7 @@ namespace MahApps.Metro.IconPacks
             = DependencyProperty.Register(
                 nameof(SpinDuration),
                 typeof(double),
-                typeof(PackIconControl<TKind>),
+                typeof(PackIconControlBase),
 #if !(NETFX_CORE || WINDOWS_UWP)
                 new PropertyMetadata(1d, SpinDurationPropertyChangedCallback, SpinDurationCoerceValueCallback));
 #else
@@ -259,7 +291,7 @@ namespace MahApps.Metro.IconPacks
 
         private static void SpinDurationPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
-            var packIcon = dependencyObject as PackIconControl<TKind>;
+            var packIcon = dependencyObject as PackIconControlBase;
             if (packIcon != null && e.OldValue != e.NewValue && packIcon.Spin && e.NewValue is double)
             {
                 packIcon.StopSpinAnimation();
@@ -296,12 +328,12 @@ namespace MahApps.Metro.IconPacks
 #else
                 typeof(IEasingFunction),
 #endif
-                typeof(PackIconControl<TKind>),
+                typeof(PackIconControlBase),
                 new PropertyMetadata(null, SpinEasingFunctionPropertyChangedCallback));
 
         private static void SpinEasingFunctionPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
-            var packIcon = dependencyObject as PackIconControl<TKind>;
+            var packIcon = dependencyObject as PackIconControlBase;
             if (packIcon != null && e.OldValue != e.NewValue && packIcon.Spin)
             {
                 packIcon.StopSpinAnimation();
@@ -334,12 +366,12 @@ namespace MahApps.Metro.IconPacks
             = DependencyProperty.Register(
                 nameof(SpinAutoReverse),
                 typeof(bool),
-                typeof(PackIconControl<TKind>),
+                typeof(PackIconControlBase),
                 new PropertyMetadata(default(bool), SpinAutoReversePropertyChangedCallback));
 
         private static void SpinAutoReversePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
-            var packIcon = dependencyObject as PackIconControl<TKind>;
+            var packIcon = dependencyObject as PackIconControlBase;
             if (packIcon != null && e.OldValue != e.NewValue && packIcon.Spin && e.NewValue is bool)
             {
                 packIcon.StopSpinAnimation();

--- a/src/MahApps.Metro.IconPacks.Core/PackIconExtension.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PackIconExtension.cs
@@ -29,9 +29,10 @@ namespace MahApps.Metro.IconPacks
 
     public static class PackIconExtensionHelper
     {
-        public static PackIconControl<TKind> GetPackIcon<TPack, TKind>(this IPackIconExtension packIconExtension, TKind kind) where TPack : PackIconControl<TKind>, new()
+        public static PackIconControlBase GetPackIcon<TPack, TKind>(this IPackIconExtension packIconExtension, TKind kind) where TPack : PackIconControlBase, new()
         {
-            var packIcon = new TPack {Kind = kind};
+            var packIcon = new TPack();
+            packIcon.SetKind(kind);
             if (packIconExtension.Width != null)
                 packIcon.Width = packIconExtension.Width.Value;
             if (packIconExtension.Height != null)
@@ -57,7 +58,7 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconBase))]
 #endif
-    public abstract class PackIconExtension<TPack, TKind> : MarkupExtension, IPackIconExtension where TPack : PackIconControl<TKind>, new()
+    public abstract class PackIconExtension<TPack, TKind> : MarkupExtension, IPackIconExtension where TPack : PackIconControlBase, new()
     {
 #if !(NETFX_CORE || WINDOWS_UWP)
         [ConstructorArgument("kind")]

--- a/src/MahApps.Metro.IconPacks.Core/PackIconExtension.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PackIconExtension.cs
@@ -58,13 +58,8 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconBase))]
 #endif
-    public abstract class PackIconExtension<TPack, TKind> : MarkupExtension, IPackIconExtension where TPack : PackIconControlBase, new()
+    public abstract class BasePackIconExtension : MarkupExtension, IPackIconExtension
     {
-#if !(NETFX_CORE || WINDOWS_UWP)
-        [ConstructorArgument("kind")]
-#endif
-        public TKind Kind { get; set; }
-
         public double? Width { get; set; }
         public double? Height { get; set; }
         public PackIconFlipOrientation? Flip { get; set; }
@@ -77,23 +72,5 @@ namespace MahApps.Metro.IconPacks
         public IEasingFunction SpinEasingFunction { get; set; }
 #endif
         public double? SpinDuration { get; set; }
-
-        protected PackIconExtension()
-        {
-        }
-
-        protected PackIconExtension(TKind kind)
-        {
-            this.Kind = kind;
-        }
-
-#if (NETFX_CORE || WINDOWS_UWP)
-        protected override object ProvideValue()
-#else
-        public override object ProvideValue(IServiceProvider serviceProvider)
-#endif
-        {
-            return this.GetPackIcon<TPack, TKind>(this.Kind);
-        }
     }
 }

--- a/src/MahApps.Metro.IconPacks.Core/PathIconBase.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PathIconBase.cs
@@ -1,73 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Media;
+﻿using Windows.UI.Xaml.Controls;
 
 namespace MahApps.Metro.IconPacks
 {
     public abstract class PathIconBase : PathIcon
     {
-        internal abstract void UpdateData();
-    }
-
-    /// <summary>
-    /// Base class for creating a PathIcon for IconPacks.
-    /// </summary>
-    /// <typeparam name="TKind"></typeparam>
-    public abstract class PathIconBase<TKind> : PathIconBase
-    {
-        private static Lazy<IDictionary<TKind, string>> _dataIndex;
-
-        /// <param name="dataIndexFactory">
-        /// Inheritors should provide a factory for setting up the path data index (per icon kind).
-        /// The factory will only be utilized once, across all closed instances (first instantiation wins).
-        /// </param>
-        protected PathIconBase(Func<IDictionary<TKind, string>> dataIndexFactory)
-        {
-            if (dataIndexFactory == null) throw new ArgumentNullException(nameof(dataIndexFactory));
-
-            if (_dataIndex == null)
-                _dataIndex = new Lazy<IDictionary<TKind, string>>(dataIndexFactory);
-        }
-
-        public static readonly DependencyProperty KindProperty
-            = DependencyProperty.Register(nameof(Kind), typeof(TKind), typeof(PathIconBase<TKind>), new PropertyMetadata(default(TKind), KindPropertyChangedCallback));
-
-        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-        {
-            ((PathIconBase) dependencyObject).UpdateData();
-        }
-
-        /// <summary>
-        /// Gets or sets the icon to display.
-        /// </summary>
-        public TKind Kind
-        {
-            get { return (TKind) GetValue(KindProperty); }
-            set { SetValue(KindProperty, value); }
-        }
-
-        protected override void OnApplyTemplate()
-        {
-            base.OnApplyTemplate();
-
-            UpdateData();
-        }
-
-        internal override void UpdateData()
-        {
-            string data = null;
-            _dataIndex.Value?.TryGetValue(Kind, out data);
-            if (string.IsNullOrEmpty(data))
-            {
-                this.Data = default(Geometry);
-            }
-            else
-            {
-                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
-            }
-        }
+        protected abstract void UpdateData();
     }
 }

--- a/src/MahApps.Metro.IconPacks.Core/PathIconControlBase.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PathIconControlBase.cs
@@ -11,16 +11,14 @@ using MahApps.Metro.IconPacks.Converter;
 namespace MahApps.Metro.IconPacks
 {
     /// <summary>
-    /// Class PathIconControl which is the base class for any PathIcon control.
+    /// Class PathIconControlBase which is the base class for any PathIcon control.
     /// </summary>
-    /// <typeparam name="TKind">The type of the enum kind.</typeparam>
-    /// <seealso cref="PathIconControl{TKind}" />
-    public class PathIconControl<TKind> : PathIconBase<TKind>
+    public abstract class PathIconControlBase : PathIconBase
     {
         private long _opacityRegisterToken;
         private long _visibilityRegisterToken;
 
-        public PathIconControl(Func<IDictionary<TKind, string>> dataIndexFactory) : base(dataIndexFactory)
+        public PathIconControlBase()
         {
             this.SetValue(RenderTransformOriginProperty, new Point(0.5, 0.5));
             this.CreateRenderTransformGroup();
@@ -62,7 +60,7 @@ namespace MahApps.Metro.IconPacks
 
         private void CoerceSpinProperty(DependencyObject sender, DependencyProperty dp)
         {
-            var pathIcon = sender as PathIconControl<TKind>;
+            var pathIcon = sender as PathIconControlBase;
             if (pathIcon != null && (dp == OpacityProperty || dp == VisibilityProperty))
             {
                 var spin = this.Spin && pathIcon.Visibility == Visibility.Visible && pathIcon.SpinDuration > 0 && pathIcon.Opacity > 0;
@@ -73,7 +71,11 @@ namespace MahApps.Metro.IconPacks
         protected override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
+
+            UpdateData();
+
             this.CoerceSpinProperty(this, SpinProperty);
+
             if (this.Spin)
             {
                 this.StopSpinAnimation();
@@ -88,7 +90,7 @@ namespace MahApps.Metro.IconPacks
             = DependencyProperty.Register(
                 nameof(Flip),
                 typeof(PackIconFlipOrientation),
-                typeof(PathIconControl<TKind>),
+                typeof(PathIconControlBase),
                 new PropertyMetadata(PackIconFlipOrientation.Normal));
 
         /// <summary>
@@ -107,7 +109,7 @@ namespace MahApps.Metro.IconPacks
             = DependencyProperty.Register(
                 nameof(RotationAngle),
                 typeof(double),
-                typeof(PathIconControl<TKind>),
+                typeof(PathIconControlBase),
                 new PropertyMetadata(0d));
 
         /// <summary>
@@ -127,12 +129,12 @@ namespace MahApps.Metro.IconPacks
             = DependencyProperty.Register(
                 nameof(Spin),
                 typeof(bool),
-                typeof(PathIconControl<TKind>),
+                typeof(PathIconControlBase),
                 new PropertyMetadata(default(bool), SpinPropertyChangedCallback));
 
         private static void SpinPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
-            var pathIcon = dependencyObject as PathIconControl<TKind>;
+            var pathIcon = dependencyObject as PathIconControlBase;
             if (pathIcon != null && e.OldValue != e.NewValue && e.NewValue is bool)
             {
                 pathIcon.ToggleSpinAnimation((bool)e.NewValue);
@@ -218,12 +220,12 @@ namespace MahApps.Metro.IconPacks
             = DependencyProperty.Register(
                 nameof(SpinDuration),
                 typeof(double),
-                typeof(PathIconControl<TKind>),
+                typeof(PathIconControlBase),
                 new PropertyMetadata(1d, SpinDurationPropertyChangedCallback));
 
         private static void SpinDurationPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
-            var pathIcon = dependencyObject as PathIconControl<TKind>;
+            var pathIcon = dependencyObject as PathIconControlBase;
             if (pathIcon != null && e.OldValue != e.NewValue && pathIcon.Spin && e.NewValue is double)
             {
                 pathIcon.StopSpinAnimation();
@@ -248,12 +250,12 @@ namespace MahApps.Metro.IconPacks
             = DependencyProperty.Register(
                 nameof(SpinEasingFunction),
                 typeof(EasingFunctionBase),
-                typeof(PathIconControl<TKind>),
+                typeof(PathIconControlBase),
                 new PropertyMetadata(null, SpinEasingFunctionPropertyChangedCallback));
 
         private static void SpinEasingFunctionPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
-            var pathIcon = dependencyObject as PathIconControl<TKind>;
+            var pathIcon = dependencyObject as PathIconControlBase;
             if (pathIcon != null && e.OldValue != e.NewValue && pathIcon.Spin)
             {
                 pathIcon.StopSpinAnimation();
@@ -278,12 +280,12 @@ namespace MahApps.Metro.IconPacks
             = DependencyProperty.Register(
                 nameof(SpinAutoReverse),
                 typeof(bool),
-                typeof(PathIconControl<TKind>),
+                typeof(PathIconControlBase),
                 new PropertyMetadata(default(bool), SpinAutoReversePropertyChangedCallback));
 
         private static void SpinAutoReversePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
-            var pathIcon = dependencyObject as PathIconControl<TKind>;
+            var pathIcon = dependencyObject as PathIconControlBase;
             if (pathIcon != null && e.OldValue != e.NewValue && pathIcon.Spin && e.NewValue is bool)
             {
                 pathIcon.StopSpinAnimation();

--- a/src/MahApps.Metro.IconPacks.Core/PathIconControlBase.cs
+++ b/src/MahApps.Metro.IconPacks.Core/PathIconControlBase.cs
@@ -21,6 +21,9 @@ namespace MahApps.Metro.IconPacks
         public PathIconControlBase()
         {
             this.SetValue(RenderTransformOriginProperty, new Point(0.5, 0.5));
+            this.SetValue(FlowDirectionProperty, FlowDirection.LeftToRight);
+            this.SetValue(HorizontalAlignmentProperty, HorizontalAlignment.Left);
+            this.SetValue(VerticalAlignmentProperty, VerticalAlignment.Top);
             this.CreateRenderTransformGroup();
 
             this.Loaded += (sender, args) =>

--- a/src/MahApps.Metro.IconPacks/PackIconBoxIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconBoxIcons.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// BoxIcons licensed under [SIL OFL 1.1](<see><cref>http://scripts.sil.org/OFL</cref></see>)
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/atisawd/boxicons</cref></see>.
     /// </summary>
-    public class PackIconBoxIcons : PackIconControl<PackIconBoxIconsKind>
+    public class PackIconBoxIcons : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconBoxIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconBoxIconsKind), typeof(PackIconBoxIcons), new PropertyMetadata(default(PackIconBoxIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconBoxIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconBoxIconsKind Kind
+        {
+            get { return (PackIconBoxIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconBoxIcons()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconBoxIcons() : base(PackIconBoxIconsDataFactory.Create)
+        public PackIconBoxIcons()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconBoxIcons);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconBoxIconsKind, string>>(PackIconBoxIconsDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconBoxIcons.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconBoxIconsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconBoxIconsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconBoxIcons))]
 #endif
-    public class BoxIconsExtension : PackIconExtension<PackIconBoxIcons, PackIconBoxIconsKind>
+    public class BoxIconsExtension : BasePackIconExtension
     {
         public BoxIconsExtension()
         {
         }
 
-        public BoxIconsExtension(PackIconBoxIconsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public BoxIconsExtension(PackIconBoxIconsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconBoxIconsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconBoxIcons, PackIconBoxIconsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconControl.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconControl.cs
@@ -1,22 +1,35 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-#if NETFX_CORE || WINDOWS_UWP
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Media.Animation;
+using Windows.UI.Xaml.Data;
 #else
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media;
-using System.Windows.Media.Animation;
 #endif
 
 namespace MahApps.Metro.IconPacks
 {
-    public class PackIconControl : PackIconControl<Enum>
+    public class PackIconControl : PackIconControlBase
     {
+        private static Lazy<IDictionary<Enum, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(Enum), typeof(PackIconBoxIcons), new PropertyMetadata(default(Enum), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconControl)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public Enum Kind
+        {
+            get { return (Enum)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconControl()
         {
@@ -24,11 +37,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconControl() : base(PackIconControlDataFactory.Create)
+        public PackIconControl()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconControl);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<Enum, string>>(PackIconControlDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconControl.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconControl.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconControl.cs
@@ -9,6 +9,8 @@ using System.Windows;
 
 namespace MahApps.Metro.IconPacks
 {
+    /// <summary>
+    /// </summary>
     public class PackIconControl : PackIconControlBase
     {
         private static Lazy<IDictionary<Enum, string>> _dataIndex;

--- a/src/MahApps.Metro.IconPacks/PackIconEntypo.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconEntypo.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from Entypo+ Icons Font <see><cref>http://www.entypo.com</cref></see>
     /// Licensed under <see><cref>http://creativecommons.org/licenses/by-sa/4.0/</cref></see>.
     /// </summary>
-    public class PackIconEntypo : PackIconControl<PackIconEntypoKind>
+    public class PackIconEntypo : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconEntypoKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconEntypoKind), typeof(PackIconEntypo), new PropertyMetadata(default(PackIconEntypoKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconEntypo)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconEntypoKind Kind
+        {
+            get { return (PackIconEntypoKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconEntypo()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconEntypo() : base(PackIconEntypoDataFactory.Create)
+        public PackIconEntypo()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconEntypo);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconEntypoKind, string>>(PackIconEntypoDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconEntypo.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconEntypoExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconEntypoExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconEntypo))]
 #endif
-    public class EntypoExtension : PackIconExtension<PackIconEntypo, PackIconEntypoKind>
+    public class EntypoExtension : BasePackIconExtension
     {
         public EntypoExtension()
         {
         }
 
-        public EntypoExtension(PackIconEntypoKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public EntypoExtension(PackIconEntypoKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconEntypoKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconEntypo, PackIconEntypoKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconEvaIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconEvaIcons.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// eva-icons licensed under the MIT License <see><cref>https://github.com/akveo/eva-icons/blob/master/LICENSE.txt</cref></see>
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/akveo/eva-icons</cref></see>.
     /// </summary>
-    public class PackIconEvaIcons : PackIconControl<PackIconEvaIconsKind>
+    public class PackIconEvaIcons : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconEvaIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconEvaIconsKind), typeof(PackIconEvaIcons), new PropertyMetadata(default(PackIconEvaIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconEvaIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconEvaIconsKind Kind
+        {
+            get { return (PackIconEvaIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconEvaIcons()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconEvaIcons() : base(PackIconEvaIconsDataFactory.Create)
+        public PackIconEvaIcons()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconEvaIcons);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconEvaIconsKind, string>>(PackIconEvaIconsDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconEvaIcons.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconEvaIconsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconEvaIconsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconEvaIcons))]
 #endif
-    public class EvaIconsExtension : PackIconExtension<PackIconEvaIcons, PackIconEvaIconsKind>
+    public class EvaIconsExtension : BasePackIconExtension
     {
         public EvaIconsExtension()
         {
         }
 
-        public EvaIconsExtension(PackIconEvaIconsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public EvaIconsExtension(PackIconEvaIconsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconEvaIconsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconEvaIcons, PackIconEvaIconsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconFeatherIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconFeatherIcons.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// Feather is licensed under the MIT License <see><cref>https://github.com/feathericons/feather/blob/master/LICENSE</cref></see>
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/feathericons/feather</cref></see>.
     /// </summary>
-    public class PackIconFeatherIcons : PackIconControl<PackIconFeatherIconsKind>
+    public class PackIconFeatherIcons : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconFeatherIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconFeatherIconsKind), typeof(PackIconFeatherIcons), new PropertyMetadata(default(PackIconFeatherIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconFeatherIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconFeatherIconsKind Kind
+        {
+            get { return (PackIconFeatherIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconFeatherIcons()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconFeatherIcons() : base(PackIconFeatherIconsDataFactory.Create)
+        public PackIconFeatherIcons()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconFeatherIcons);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconFeatherIconsKind, string>>(PackIconFeatherIconsDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconFeatherIcons.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconFeatherIconsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconFeatherIconsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconFeatherIcons))]
 #endif
-    public class FeatherIconsExtension : PackIconExtension<PackIconFeatherIcons, PackIconFeatherIconsKind>
+    public class FeatherIconsExtension : BasePackIconExtension
     {
         public FeatherIconsExtension()
         {
         }
 
-        public FeatherIconsExtension(PackIconFeatherIconsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public FeatherIconsExtension(PackIconFeatherIconsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconFeatherIconsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconFeatherIcons, PackIconFeatherIconsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconFontAwesome.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconFontAwesome.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from Font Awesome Free <see><cref>https://fontawesome.com/</cref></see> - License <see><cref>https://fontawesome.com/license/free</cref></see>
     /// GitHub <see><cref>https://github.com/FortAwesome/Font-Awesome</cref></see>
     /// </summary>
-    public class PackIconFontAwesome : PackIconControl<PackIconFontAwesomeKind>
+    public class PackIconFontAwesome : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconFontAwesomeKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconFontAwesomeKind), typeof(PackIconFontAwesome), new PropertyMetadata(default(PackIconFontAwesomeKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconFontAwesome)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconFontAwesomeKind Kind
+        {
+            get { return (PackIconFontAwesomeKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconFontAwesome()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconFontAwesome() : base(PackIconFontAwesomeDataFactory.Create)
+        public PackIconFontAwesome()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconFontAwesome);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconFontAwesomeKind, string>>(PackIconFontAwesomeDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconFontAwesome.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconFontAwesomeExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconFontAwesomeExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconFontAwesome))]
 #endif
-    public class FontAwesomeExtension : PackIconExtension<PackIconFontAwesome, PackIconFontAwesomeKind>
+    public class FontAwesomeExtension : BasePackIconExtension
     {
         public FontAwesomeExtension()
         {
         }
 
-        public FontAwesomeExtension(PackIconFontAwesomeKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public FontAwesomeExtension(PackIconFontAwesomeKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconFontAwesomeKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconFontAwesome, PackIconFontAwesomeKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconIonicons.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconIonicons.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// Ionicons is licensed under the [MIT license](<see><cref>https://github.com/ionic-team/ionicons/blob/master/LICENSE</cref></see>).
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/ionic-team/ionicons</cref></see>.
     /// </summary>
-    public class PackIconIonicons : PackIconControl<PackIconIoniconsKind>
+    public class PackIconIonicons : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconIoniconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconIoniconsKind), typeof(PackIconIonicons), new PropertyMetadata(default(PackIconIoniconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconIonicons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconIoniconsKind Kind
+        {
+            get { return (PackIconIoniconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconIonicons()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconIonicons() : base(PackIconIoniconsDataFactory.Create)
+        public PackIconIonicons()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconIonicons);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconIoniconsKind, string>>(PackIconIoniconsDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconIonicons.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconIoniconsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconIoniconsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconIonicons))]
 #endif
-    public class IoniconsExtension : PackIconExtension<PackIconIonicons, PackIconIoniconsKind>
+    public class IoniconsExtension : BasePackIconExtension
     {
         public IoniconsExtension()
         {
         }
 
-        public IoniconsExtension(PackIconIoniconsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public IoniconsExtension(PackIconIoniconsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconIoniconsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconIonicons, PackIconIoniconsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconJamIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconJamIcons.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// Jam Icons licensed under the MIT License <see><cref>https://github.com/michaelampr/jam/blob/master/LICENSE</cref></see>
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/michaelampr/jam</cref></see>.
     /// </summary>
-    public class PackIconJamIcons : PackIconControl<PackIconJamIconsKind>
+    public class PackIconJamIcons : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconJamIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconJamIconsKind), typeof(PackIconJamIcons), new PropertyMetadata(default(PackIconJamIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconJamIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconJamIconsKind Kind
+        {
+            get { return (PackIconJamIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconJamIcons()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconJamIcons() : base(PackIconJamIconsDataFactory.Create)
+        public PackIconJamIcons()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconJamIcons);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconJamIconsKind, string>>(PackIconJamIconsDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconJamIcons.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconJamIconsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconJamIconsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconJamIcons))]
 #endif
-    public class JamIconsExtension : PackIconExtension<PackIconJamIcons, PackIconJamIconsKind>
+    public class JamIconsExtension : BasePackIconExtension
     {
         public JamIconsExtension()
         {
         }
 
-        public JamIconsExtension(PackIconJamIconsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public JamIconsExtension(PackIconJamIconsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconJamIconsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconJamIcons, PackIconJamIconsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconMaterial.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconMaterial.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from Material Design Icons Font v1.6.50 - <see><cref>https://materialdesignicons.com</cref></see> - in accordance of
     /// <see><cref>https://github.com/Templarian/MaterialDesign/blob/master/license.txt</cref></see>.
     /// </summary>
-    public class PackIconMaterial : PackIconControl<PackIconMaterialKind>
+    public class PackIconMaterial : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconMaterialKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconMaterialKind), typeof(PackIconMaterial), new PropertyMetadata(default(PackIconMaterialKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconMaterial)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconMaterialKind Kind
+        {
+            get { return (PackIconMaterialKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconMaterial()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconMaterial() : base(PackIconMaterialDataFactory.Create)
+        public PackIconMaterial()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconMaterial);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconMaterialKind, string>>(PackIconMaterialDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconMaterial.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconMaterialDesign.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconMaterialDesign.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from Google Material Design icon font - <see><cref>http://google.github.io/material-design-icons/</cref></see>
     /// google/material-design-icons is licensed under the Apache License 2.0 <see><cref>https://github.com/google/material-design-icons/blob/master/LICENSE</cref></see>
     /// </summary>
-    public class PackIconMaterialDesign : PackIconControl<PackIconMaterialDesignKind>
+    public class PackIconMaterialDesign : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconMaterialDesignKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconMaterialDesignKind), typeof(PackIconMaterialDesign), new PropertyMetadata(default(PackIconMaterialDesignKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconMaterialDesign)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconMaterialDesignKind Kind
+        {
+            get { return (PackIconMaterialDesignKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconMaterialDesign()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconMaterialDesign() : base(PackIconMaterialDesignDataFactory.Create)
+        public PackIconMaterialDesign()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconMaterialDesign);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconMaterialDesignKind, string>>(PackIconMaterialDesignDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconMaterialDesign.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconMaterialDesignExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconMaterialDesignExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconMaterialDesign))]
 #endif
-    public class MaterialDesignExtension : PackIconExtension<PackIconMaterialDesign, PackIconMaterialDesignKind>
+    public class MaterialDesignExtension : BasePackIconExtension
     {
         public MaterialDesignExtension()
         {
         }
 
-        public MaterialDesignExtension(PackIconMaterialDesignKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public MaterialDesignExtension(PackIconMaterialDesignKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconMaterialDesignKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconMaterialDesign, PackIconMaterialDesignKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconMaterialExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconMaterialExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconMaterial))]
 #endif
-    public class MaterialExtension : PackIconExtension<PackIconMaterial, PackIconMaterialKind>
+    public class MaterialExtension : BasePackIconExtension
     {
         public MaterialExtension()
         {
         }
 
-        public MaterialExtension(PackIconMaterialKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public MaterialExtension(PackIconMaterialKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconMaterialKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconMaterial, PackIconMaterialKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconMaterialLight.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconMaterialLight.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from Material Design Light Icons - <see><cref>https://github.com/Templarian/MaterialDesignLight</cref></see> - in accordance of
     /// <see><cref>https://github.com/Templarian/MaterialDesignLight/blob/master/LICENSE.md</cref></see>.
     /// </summary>
-    public class PackIconMaterialLight : PackIconControl<PackIconMaterialLightKind>
+    public class PackIconMaterialLight : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconMaterialLightKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconMaterialLightKind), typeof(PackIconMaterialLight), new PropertyMetadata(default(PackIconMaterialLightKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconMaterialLight)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconMaterialLightKind Kind
+        {
+            get { return (PackIconMaterialLightKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconMaterialLight()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconMaterialLight() : base(PackIconMaterialLightDataFactory.Create)
+        public PackIconMaterialLight()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconMaterialLight);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconMaterialLightKind, string>>(PackIconMaterialLightDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconMaterialLight.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconMaterialLightExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconMaterialLightExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconMaterialLight))]
 #endif
-    public class MaterialLightExtension : PackIconExtension<PackIconMaterialLight, PackIconMaterialLightKind>
+    public class MaterialLightExtension : BasePackIconExtension
     {
         public MaterialLightExtension()
         {
         }
 
-        public MaterialLightExtension(PackIconMaterialLightKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public MaterialLightExtension(PackIconMaterialLightKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconMaterialLightKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconMaterialLight, PackIconMaterialLightKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconModernExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconModernExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconModern))]
 #endif
-    public class ModernExtension : PackIconExtension<PackIconModern, PackIconModernKind>
+    public class ModernExtension : BasePackIconExtension
     {
         public ModernExtension()
         {
         }
 
-        public ModernExtension(PackIconModernKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public ModernExtension(PackIconModernKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconModernKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconModern, PackIconModernKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconOcticonsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconOcticonsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconOcticons))]
 #endif
-    public class OcticonsExtension : PackIconExtension<PackIconOcticons, PackIconOcticonsKind>
+    public class OcticonsExtension : BasePackIconExtension
     {
         public OcticonsExtension()
         {
         }
 
-        public OcticonsExtension(PackIconOcticonsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public OcticonsExtension(PackIconOcticonsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconOcticonsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconOcticons, PackIconOcticonsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconPicolIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconPicolIcons.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// The PICOL icons are licensed under [Artistic License 2.0, Attribution 3.0 Unported (CC BY 3.0)](<see><cref>https://creativecommons.org/licenses/by/3.0/</cref></see>).
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/PicolSigns</cref></see>.
     /// </summary>
-    public class PackIconPicolIcons : PackIconControl<PackIconPicolIconsKind>
+    public class PackIconPicolIcons : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconPicolIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconPicolIconsKind), typeof(PackIconPicolIcons), new PropertyMetadata(default(PackIconPicolIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconPicolIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconPicolIconsKind Kind
+        {
+            get { return (PackIconPicolIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconPicolIcons()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconPicolIcons() : base(PackIconPicolIconsDataFactory.Create)
+        public PackIconPicolIcons()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconPicolIcons);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconPicolIconsKind, string>>(PackIconPicolIconsDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconPicolIcons.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconPicolIconsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconPicolIconsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconPicolIcons))]
 #endif
-    public class PicolIconsExtension : PackIconExtension<PackIconPicolIcons, PackIconPicolIconsKind>
+    public class PicolIconsExtension : BasePackIconExtension
     {
         public PicolIconsExtension()
         {
         }
 
-        public PicolIconsExtension(PackIconPicolIconsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public PicolIconsExtension(PackIconPicolIconsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconPicolIconsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconPicolIcons, PackIconPicolIconsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconRPGAwesome.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconRPGAwesome.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// The Rpg Awesome font is licensed under the [SIL OFL 1.1](<see><cref>http://scripts.sil.org/OFL</cref></see>)
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/nagoshiashumari/Rpg-Awesome</cref></see>.
     /// </summary>
-    public class PackIconRPGAwesome : PackIconControl<PackIconRPGAwesomeKind>
+    public class PackIconRPGAwesome : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconRPGAwesomeKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconRPGAwesomeKind), typeof(PackIconRPGAwesome), new PropertyMetadata(default(PackIconRPGAwesomeKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconRPGAwesome)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconRPGAwesomeKind Kind
+        {
+            get { return (PackIconRPGAwesomeKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconRPGAwesome()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconRPGAwesome() : base(PackIconRPGAwesomeDataFactory.Create)
+        public PackIconRPGAwesome()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconRPGAwesome);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconRPGAwesomeKind, string>>(PackIconRPGAwesomeDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconRPGAwesome.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconRPGAwesomeExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconRPGAwesomeExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconRPGAwesome))]
 #endif
-    public class RPGAwesomeExtension : PackIconExtension<PackIconRPGAwesome, PackIconRPGAwesomeKind>
+    public class RPGAwesomeExtension : BasePackIconExtension
     {
         public RPGAwesomeExtension()
         {
         }
 
-        public RPGAwesomeExtension(PackIconRPGAwesomeKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public RPGAwesomeExtension(PackIconRPGAwesomeKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconRPGAwesomeKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconRPGAwesome, PackIconRPGAwesomeKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconSimpleIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconSimpleIcons.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// All SVG icons for popular brands, maintained by Dan Leech <see><cref>https://twitter.com/bathtype</cref></see>.
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/danleech/simple-icons</cref></see>.
     /// </summary>
-    public class PackIconSimpleIcons : PackIconControl<PackIconSimpleIconsKind>
+    public class PackIconSimpleIcons : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconSimpleIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconSimpleIconsKind), typeof(PackIconSimpleIcons), new PropertyMetadata(default(PackIconSimpleIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconSimpleIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconSimpleIconsKind Kind
+        {
+            get { return (PackIconSimpleIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconSimpleIcons()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconSimpleIcons() : base(PackIconSimpleIconsDataFactory.Create)
+        public PackIconSimpleIcons()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconSimpleIcons);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconSimpleIconsKind, string>>(PackIconSimpleIconsDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconSimpleIcons.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconSimpleIconsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconSimpleIconsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconSimpleIcons))]
 #endif
-    public class SimpleIconsExtension : PackIconExtension<PackIconSimpleIcons, PackIconSimpleIconsKind>
+    public class SimpleIconsExtension : BasePackIconExtension
     {
         public SimpleIconsExtension()
         {
         }
 
-        public SimpleIconsExtension(PackIconSimpleIconsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public SimpleIconsExtension(PackIconSimpleIconsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconSimpleIconsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconSimpleIcons, PackIconSimpleIconsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconTypiconsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconTypiconsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconTypicons))]
 #endif
-    public class TypiconsExtension : PackIconExtension<PackIconTypicons, PackIconTypiconsKind>
+    public class TypiconsExtension : BasePackIconExtension
     {
         public TypiconsExtension()
         {
         }
 
-        public TypiconsExtension(PackIconTypiconsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public TypiconsExtension(PackIconTypiconsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconTypiconsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconTypicons, PackIconTypiconsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconUnicons.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconUnicons.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// Unicons are Open Source icons and licensed under [Apache 2.0](<see><cref>https://www.apache.org/licenses/LICENSE-2.0.txt</cref></see>). You're free to use these icons in your personal and commercial project. We would love to see the attribution in your app's **about** screen, but it's not mandatory.
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/Iconscout/unicons</cref></see>.
     /// </summary>
-    public class PackIconUnicons : PackIconControl<PackIconUniconsKind>
+    public class PackIconUnicons : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconUniconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconUniconsKind), typeof(PackIconUnicons), new PropertyMetadata(default(PackIconUniconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconUnicons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconUniconsKind Kind
+        {
+            get { return (PackIconUniconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconUnicons()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconUnicons() : base(PackIconUniconsDataFactory.Create)
+        public PackIconUnicons()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconUnicons);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconUniconsKind, string>>(PackIconUniconsDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconUnicons.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconUniconsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconUniconsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconUnicons))]
 #endif
-    public class UniconsExtension : PackIconExtension<PackIconUnicons, PackIconUniconsKind>
+    public class UniconsExtension : BasePackIconExtension
     {
         public UniconsExtension()
         {
         }
 
-        public UniconsExtension(PackIconUniconsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public UniconsExtension(PackIconUniconsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconUniconsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconUnicons, PackIconUniconsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconWeatherIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconWeatherIcons.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// Weather Icons licensed under [SIL OFL 1.1](<see><cref>http://scripts.sil.org/OFL</cref></see>)
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/erikflowers/weather-icons</cref></see>.
     /// </summary>
-    public class PackIconWeatherIcons : PackIconControl<PackIconWeatherIconsKind>
+    public class PackIconWeatherIcons : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconWeatherIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconWeatherIconsKind), typeof(PackIconWeatherIcons), new PropertyMetadata(default(PackIconWeatherIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconWeatherIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconWeatherIconsKind Kind
+        {
+            get { return (PackIconWeatherIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconWeatherIcons()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconWeatherIcons() : base(PackIconWeatherIconsDataFactory.Create)
+        public PackIconWeatherIcons()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconWeatherIcons);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconWeatherIconsKind, string>>(PackIconWeatherIconsDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconWeatherIcons.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconWeatherIconsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconWeatherIconsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconWeatherIcons))]
 #endif
-    public class WeatherIconsExtension : PackIconExtension<PackIconWeatherIcons, PackIconWeatherIconsKind>
+    public class WeatherIconsExtension : BasePackIconExtension
     {
         public WeatherIconsExtension()
         {
         }
 
-        public WeatherIconsExtension(PackIconWeatherIconsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public WeatherIconsExtension(PackIconWeatherIconsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconWeatherIconsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconWeatherIcons, PackIconWeatherIconsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconZondicons.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconZondicons.cs
@@ -1,5 +1,9 @@
-﻿
-#if !(NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+using System.Collections.Generic;
+#if (NETFX_CORE || WINDOWS_UWP)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+#else
 using System.Windows;
 #endif
 
@@ -9,8 +13,27 @@ namespace MahApps.Metro.IconPacks
     /// Zondicons is licensed under the [CC BY 4.0](<see><cref>https://creativecommons.org/licenses/by/4.0/</cref></see>).
     /// Zondicons are availabe at <see><cref>https://www.zondicons.com/</cref></see>.
     /// </summary>
-    public class PackIconZondicons : PackIconControl<PackIconZondiconsKind>
+    public class PackIconZondicons : PackIconControlBase
     {
+        private static Lazy<IDictionary<PackIconZondiconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconZondiconsKind), typeof(PackIconZondicons), new PropertyMetadata(default(PackIconZondiconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            ((PackIconZondicons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconZondiconsKind Kind
+        {
+            get { return (PackIconZondiconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
 #if !(NETFX_CORE || WINDOWS_UWP)
         static PackIconZondicons()
         {
@@ -18,11 +41,32 @@ namespace MahApps.Metro.IconPacks
         }
 #endif
 
-        public PackIconZondicons() : base(PackIconZondiconsDataFactory.Create)
+        public PackIconZondicons()
         {
 #if NETFX_CORE || WINDOWS_UWP
             this.DefaultStyleKey = typeof(PackIconZondicons);
 #endif
+
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconZondiconsKind, string>>(PackIconZondiconsDataFactory.Create);
+            }
+        }
+
+        protected override void SetKind<TKind>(TKind iconKind)
+        {
+#if NETFX_CORE || WINDOWS_UWP
+            BindingOperations.SetBinding(this, PackIconZondicons.KindProperty, new Binding() { Source = iconKind, Mode = BindingMode.OneTime });
+#else
+            this.SetCurrentValue(KindProperty, iconKind);
+#endif
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            this.Data = data;
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PackIconZondiconsExtension.cs
+++ b/src/MahApps.Metro.IconPacks/PackIconZondiconsExtension.cs
@@ -1,4 +1,5 @@
-﻿#if (NETFX_CORE || WINDOWS_UWP)
+﻿using System;
+#if (NETFX_CORE || WINDOWS_UWP)
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
@@ -15,14 +16,29 @@ namespace MahApps.Metro.IconPacks
 #else
     [MarkupExtensionReturnType(typeof(PackIconZondicons))]
 #endif
-    public class ZondiconsExtension : PackIconExtension<PackIconZondicons, PackIconZondiconsKind>
+    public class ZondiconsExtension : BasePackIconExtension
     {
         public ZondiconsExtension()
         {
         }
 
-        public ZondiconsExtension(PackIconZondiconsKind kind) : base(kind)
+#if !(NETFX_CORE || WINDOWS_UWP)
+        public ZondiconsExtension(PackIconZondiconsKind kind)
         {
+            this.Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+#endif
+        public PackIconZondiconsKind Kind { get; set; }
+
+#if (NETFX_CORE || WINDOWS_UWP)
+        protected override object ProvideValue()
+#else
+        public override object ProvideValue(IServiceProvider serviceProvider)
+#endif
+        {
+            return this.GetPackIcon<PackIconZondicons, PackIconZondiconsKind>(this.Kind);
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconBoxIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconBoxIcons.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,13 +11,51 @@ namespace MahApps.Metro.IconPacks
     /// BoxIcons licensed under [SIL OFL 1.1](<see><cref>http://scripts.sil.org/OFL</cref></see>)
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/atisawd/boxicons</cref></see>.
     /// </summary>
-    public class PathIconBoxIcons : PathIconControl<PackIconBoxIconsKind>
+    public class PathIconBoxIcons : PathIconControlBase
     {
-        public PathIconBoxIcons() : base(PackIconBoxIconsDataFactory.Create)
+        private static Lazy<IDictionary<PackIconBoxIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconBoxIconsKind), typeof(PathIconBoxIcons), new PropertyMetadata(default(PackIconBoxIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconBoxIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconBoxIconsKind Kind
+        {
+            get { return (PackIconBoxIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconBoxIcons()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconBoxIconsKind, string>>(PackIconBoxIconsDataFactory.Create);
+            }
+
             var transformGroup = this.RenderTransform as TransformGroup ?? new TransformGroup();
             var scaleTransform = new ScaleTransform() {ScaleY = -1};
             transformGroup.Children.Insert(0, scaleTransform);
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconEntypo.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconEntypo.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from Entypo+ Icons Font <see><cref>http://www.entypo.com</cref></see>
     /// Licensed under <see><cref>http://creativecommons.org/licenses/by-sa/4.0/</cref></see>.
     /// </summary>
-    public class PathIconEntypo : PathIconControl<PackIconEntypoKind>
+    public class PathIconEntypo : PathIconControlBase
     {
-        public PathIconEntypo() : base(PackIconEntypoDataFactory.Create)
+        private static Lazy<IDictionary<PackIconEntypoKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconEntypoKind), typeof(PathIconEntypo), new PropertyMetadata(default(PackIconEntypoKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconEntypo)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconEntypoKind Kind
+        {
+            get { return (PackIconEntypoKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconEntypo()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconEntypoKind, string>>(PackIconEntypoDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconEvaIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconEvaIcons.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,13 +11,51 @@ namespace MahApps.Metro.IconPacks
     /// eva-icons licensed under the MIT License <see><cref>https://github.com/akveo/eva-icons/blob/master/LICENSE.txt</cref></see>
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/akveo/eva-icons</cref></see>.
     /// </summary>
-    public class PathIconEvaIcons : PathIconControl<PackIconEvaIconsKind>
+    public class PathIconEvaIcons : PathIconControlBase
     {
-        public PathIconEvaIcons() : base(PackIconEvaIconsDataFactory.Create)
+        private static Lazy<IDictionary<PackIconEvaIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconEvaIconsKind), typeof(PathIconEvaIcons), new PropertyMetadata(default(PackIconEvaIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconEvaIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconEvaIconsKind Kind
+        {
+            get { return (PackIconEvaIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconEvaIcons()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconEvaIconsKind, string>>(PackIconEvaIconsDataFactory.Create);
+            }
+
             var transformGroup = this.RenderTransform as TransformGroup ?? new TransformGroup();
             var scaleTransform = new ScaleTransform() {ScaleY = -1};
             transformGroup.Children.Insert(0, scaleTransform);
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconFontAwesome.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconFontAwesome.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from Font Awesome Free <see><cref>https://fontawesome.com/</cref></see> - License <see><cref>https://fontawesome.com/license/free</cref></see>
     /// GitHub <see><cref>https://github.com/FortAwesome/Font-Awesome</cref></see>
     /// </summary>
-    public class PathIconFontAwesome : PathIconControl<PackIconFontAwesomeKind>
+    public class PathIconFontAwesome : PathIconControlBase
     {
-        public PathIconFontAwesome() : base(PackIconFontAwesomeDataFactory.Create)
+        private static Lazy<IDictionary<PackIconFontAwesomeKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconFontAwesomeKind), typeof(PathIconFontAwesome), new PropertyMetadata(default(PackIconFontAwesomeKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconFontAwesome)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconFontAwesomeKind Kind
+        {
+            get { return (PackIconFontAwesomeKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconFontAwesome()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconFontAwesomeKind, string>>(PackIconFontAwesomeDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconIonicons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconIonicons.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// Ionicons is licensed under the [MIT license](<see><cref>https://github.com/ionic-team/ionicons/blob/master/LICENSE</cref></see>).
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/ionic-team/ionicons</cref></see>.
     /// </summary>
-    public class PathIconIonicons : PathIconControl<PackIconIoniconsKind>
+    public class PathIconIonicons : PathIconControlBase
     {
-        public PathIconIonicons() : base(PackIconIoniconsDataFactory.Create)
+        private static Lazy<IDictionary<PackIconIoniconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconIoniconsKind), typeof(PathIconIonicons), new PropertyMetadata(default(PackIconIoniconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconIonicons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconIoniconsKind Kind
+        {
+            get { return (PackIconIoniconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconIonicons()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconIoniconsKind, string>>(PackIconIoniconsDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconJamIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconJamIcons.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,13 +11,51 @@ namespace MahApps.Metro.IconPacks
     /// Jam Icons licensed under the MIT License <see><cref>https://github.com/michaelampr/jam/blob/master/LICENSE</cref></see>
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/michaelampr/jam</cref></see>.
     /// </summary>
-    public class PathIconJamIcons : PathIconControl<PackIconJamIconsKind>
+    public class PathIconJamIcons : PathIconControlBase
     {
-        public PathIconJamIcons() : base(PackIconJamIconsDataFactory.Create)
+        private static Lazy<IDictionary<PackIconJamIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconJamIconsKind), typeof(PathIconJamIcons), new PropertyMetadata(default(PackIconJamIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconJamIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconJamIconsKind Kind
+        {
+            get { return (PackIconJamIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconJamIcons()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconJamIconsKind, string>>(PackIconJamIconsDataFactory.Create);
+            }
+
             var transformGroup = this.RenderTransform as TransformGroup ?? new TransformGroup();
             var scaleTransform = new ScaleTransform() {ScaleY = -1};
             transformGroup.Children.Insert(0, scaleTransform);
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconMaterial.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconMaterial.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from Material Design Icons Font v1.6.50 - <see><cref>https://materialdesignicons.com</cref></see> - in accordance of
     /// <see><cref>https://github.com/Templarian/MaterialDesign/blob/master/license.txt</cref></see>.
     /// </summary>
-    public class PathIconMaterial : PathIconControl<PackIconMaterialKind>
+    public class PathIconMaterial : PathIconControlBase
     {
-        public PathIconMaterial() : base(PackIconMaterialDataFactory.Create)
+        private static Lazy<IDictionary<PackIconMaterialKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconMaterialKind), typeof(PathIconMaterial), new PropertyMetadata(default(PackIconMaterialKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconMaterial)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconMaterialKind Kind
+        {
+            get { return (PackIconMaterialKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconMaterial()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconMaterialKind, string>>(PackIconMaterialDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconMaterialDesign.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconMaterialDesign.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,13 +11,51 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from Google Material Design icon font - <see><cref>http://google.github.io/material-design-icons/</cref></see>
     /// google/material-design-icons is licensed under the Apache License 2.0 <see><cref>https://github.com/google/material-design-icons/blob/master/LICENSE</cref></see>
     /// </summary>
-    public class PathIconMaterialDesign : PathIconControl<PackIconMaterialDesignKind>
+    public class PathIconMaterialDesign : PathIconControlBase
     {
-        public PathIconMaterialDesign() : base(PackIconMaterialDesignDataFactory.Create)
+        private static Lazy<IDictionary<PackIconMaterialDesignKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconMaterialDesignKind), typeof(PathIconMaterialDesign), new PropertyMetadata(default(PackIconMaterialDesignKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconMaterialDesign)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconMaterialDesignKind Kind
+        {
+            get { return (PackIconMaterialDesignKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconMaterialDesign()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconMaterialDesignKind, string>>(PackIconMaterialDesignDataFactory.Create);
+            }
+
             var transformGroup = this.RenderTransform as TransformGroup ?? new TransformGroup();
             var scaleTransform = new ScaleTransform() {ScaleY = -1};
             transformGroup.Children.Insert(0, scaleTransform);
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconMaterialLight.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconMaterialLight.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from Material Design Light Icons - <see><cref>https://github.com/Templarian/MaterialDesignLight</cref></see> - in accordance of
     /// <see><cref>https://github.com/Templarian/MaterialDesignLight/blob/master/LICENSE.md</cref></see>.
     /// </summary>
-    public class PathIconMaterialLight : PathIconControl<PackIconMaterialLightKind>
+    public class PathIconMaterialLight : PathIconControlBase
     {
-        public PathIconMaterialLight() : base(PackIconMaterialLightDataFactory.Create)
+        private static Lazy<IDictionary<PackIconMaterialLightKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconMaterialLightKind), typeof(PathIconMaterialLight), new PropertyMetadata(default(PackIconMaterialLightKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconMaterialLight)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconMaterialLightKind Kind
+        {
+            get { return (PackIconMaterialLightKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconMaterialLight()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconMaterialLightKind, string>>(PackIconMaterialLightDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconModern.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconModern.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from Modern UI Icons Font - <see><cref>http://modernuiicons.com</cref></see> - in accordance of
     /// <see><cref>https://github.com/Templarian/WindowsIcons/blob/master/WindowsPhone/license.txt</cref></see>.
     /// </summary>
-    public class PathIconModern : PathIconControl<PackIconModernKind>
+    public class PathIconModern : PathIconControlBase
     {
-        public PathIconModern() : base(PackIconModernDataFactory.Create)
+        private static Lazy<IDictionary<PackIconModernKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconModernKind), typeof(PathIconModern), new PropertyMetadata(default(PackIconModernKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconModern)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconModernKind Kind
+        {
+            get { return (PackIconModernKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconModern()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconModernKind, string>>(PackIconModernDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconOcticons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconOcticons.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// All icons sourced from GitHub Octicons - <see><cref>https://octicons.github.com</cref></see> - 
     /// <see><cref>https://github.com/primer/octicons/blob/master/LICENSE</cref></see>.
     /// </summary>
-    public class PathIconOcticons : PathIconControl<PackIconOcticonsKind>
+    public class PathIconOcticons : PathIconControlBase
     {
-        public PathIconOcticons() : base(PackIconOcticonsDataFactory.Create)
+        private static Lazy<IDictionary<PackIconOcticonsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconOcticonsKind), typeof(PathIconOcticons), new PropertyMetadata(default(PackIconOcticonsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconOcticons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconOcticonsKind Kind
+        {
+            get { return (PackIconOcticonsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconOcticons()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconOcticonsKind, string>>(PackIconOcticonsDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconPicolIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconPicolIcons.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// The PICOL icons are licensed under [Artistic License 2.0, Attribution 3.0 Unported (CC BY 3.0)](<see><cref>https://creativecommons.org/licenses/by/3.0/</cref></see>).
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/PicolSigns</cref></see>.
     /// </summary>
-    public class PathIconPicolIcons : PathIconControl<PackIconPicolIconsKind>
+    public class PathIconPicolIcons : PathIconControlBase
     {
-        public PathIconPicolIcons() : base(PackIconPicolIconsDataFactory.Create)
+        private static Lazy<IDictionary<PackIconPicolIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconPicolIconsKind), typeof(PathIconPicolIcons), new PropertyMetadata(default(PackIconPicolIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconPicolIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconPicolIconsKind Kind
+        {
+            get { return (PackIconPicolIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconPicolIcons()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconPicolIconsKind, string>>(PackIconPicolIconsDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconRPGAwesome.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconRPGAwesome.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,13 +11,51 @@ namespace MahApps.Metro.IconPacks
     /// The Rpg Awesome font is licensed under the [SIL OFL 1.1](<see><cref>http://scripts.sil.org/OFL</cref></see>)
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/nagoshiashumari/Rpg-Awesome</cref></see>.
     /// </summary>
-    public class PathIconRPGAwesome : PathIconControl<PackIconRPGAwesomeKind>
+    public class PathIconRPGAwesome : PathIconControlBase
     {
-        public PathIconRPGAwesome() : base(PackIconRPGAwesomeDataFactory.Create)
+        private static Lazy<IDictionary<PackIconRPGAwesomeKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconRPGAwesomeKind), typeof(PathIconRPGAwesome), new PropertyMetadata(default(PackIconRPGAwesomeKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconRPGAwesome)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconRPGAwesomeKind Kind
+        {
+            get { return (PackIconRPGAwesomeKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconRPGAwesome()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconRPGAwesomeKind, string>>(PackIconRPGAwesomeDataFactory.Create);
+            }
+
             var transformGroup = this.RenderTransform as TransformGroup ?? new TransformGroup();
             var scaleTransform = new ScaleTransform() {ScaleY = -1};
             transformGroup.Children.Insert(0, scaleTransform);
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconSimpleIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconSimpleIcons.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// All SVG icons for popular brands, maintained by Dan Leech <see><cref>https://twitter.com/bathtype</cref></see>.
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/danleech/simple-icons</cref></see>.
     /// </summary>
-    public class PathIconSimpleIcons : PathIconControl<PackIconSimpleIconsKind>
+    public class PathIconSimpleIcons : PathIconControlBase
     {
-        public PathIconSimpleIcons() : base(PackIconSimpleIconsDataFactory.Create)
+        private static Lazy<IDictionary<PackIconSimpleIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconSimpleIconsKind), typeof(PathIconSimpleIcons), new PropertyMetadata(default(PackIconSimpleIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconSimpleIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconSimpleIconsKind Kind
+        {
+            get { return (PackIconSimpleIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconSimpleIcons()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconSimpleIconsKind, string>>(PackIconSimpleIconsDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconTypicons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconTypicons.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,13 +11,51 @@ namespace MahApps.Metro.IconPacks
     /// Typicons Icons/Artwork distributed under [CC BY-SA](<see><cref>https://creativecommons.org/licenses/by-sa/3.0/</cref></see>) licence.
     /// Typicons Font distributed under 'SIL Open Font License' licence.
     /// </summary>
-    public class PathIconTypicons : PathIconControl<PackIconTypiconsKind>
+    public class PathIconTypicons : PathIconControlBase
     {
-        public PathIconTypicons() : base(PackIconTypiconsDataFactory.Create)
+        private static Lazy<IDictionary<PackIconTypiconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconTypiconsKind), typeof(PathIconTypicons), new PropertyMetadata(default(PackIconTypiconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconTypicons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconTypiconsKind Kind
+        {
+            get { return (PackIconTypiconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconTypicons()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconTypiconsKind, string>>(PackIconTypiconsDataFactory.Create);
+            }
+
             var transformGroup = this.RenderTransform as TransformGroup ?? new TransformGroup();
             var scaleTransform = new ScaleTransform() {ScaleY = -1};
             transformGroup.Children.Insert(0, scaleTransform);
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconUnicons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconUnicons.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// Unicons are Open Source icons and licensed under [Apache 2.0](<see><cref>https://www.apache.org/licenses/LICENSE-2.0.txt</cref></see>). You're free to use these icons in your personal and commercial project. We would love to see the attribution in your app's **about** screen, but it's not mandatory.
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/Iconscout/unicons</cref></see>.
     /// </summary>
-    public class PathIconUnicons : PathIconControl<PackIconUniconsKind>
+    public class PathIconUnicons : PathIconControlBase
     {
-        public PathIconUnicons() : base(PackIconUniconsDataFactory.Create)
+        private static Lazy<IDictionary<PackIconUniconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconUniconsKind), typeof(PathIconUnicons), new PropertyMetadata(default(PackIconUniconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconUnicons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconUniconsKind Kind
+        {
+            get { return (PackIconUniconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconUnicons()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconUniconsKind, string>>(PackIconUniconsDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconWeatherIcons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconWeatherIcons.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// Weather Icons licensed under [SIL OFL 1.1](<see><cref>http://scripts.sil.org/OFL</cref></see>)
     /// Contributions, corrections and requests can be made on GitHub <see><cref>https://github.com/erikflowers/weather-icons</cref></see>.
     /// </summary>
-    public class PathIconWeatherIcons : PathIconControl<PackIconWeatherIconsKind>
+    public class PathIconWeatherIcons : PathIconControlBase
     {
-        public PathIconWeatherIcons() : base(PackIconWeatherIconsDataFactory.Create)
+        private static Lazy<IDictionary<PackIconWeatherIconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconWeatherIconsKind), typeof(PathIconWeatherIcons), new PropertyMetadata(default(PackIconWeatherIconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconWeatherIcons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconWeatherIconsKind Kind
+        {
+            get { return (PackIconWeatherIconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconWeatherIcons()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconWeatherIconsKind, string>>(PackIconWeatherIconsDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/MahApps.Metro.IconPacks/PathIconZondicons.cs
+++ b/src/MahApps.Metro.IconPacks/PathIconZondicons.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace MahApps.Metro.IconPacks
 {
@@ -6,10 +11,47 @@ namespace MahApps.Metro.IconPacks
     /// Zondicons is licensed under the [CC BY 4.0](<see><cref>https://creativecommons.org/licenses/by/4.0/</cref></see>).
     /// Zondicons are availabe at <see><cref>https://www.zondicons.com/</cref></see>.
     /// </summary>
-    public class PathIconZondicons : PathIconControl<PackIconZondiconsKind>
+    public class PathIconZondicons : PathIconControlBase
     {
-        public PathIconZondicons() : base(PackIconZondiconsDataFactory.Create)
+        private static Lazy<IDictionary<PackIconZondiconsKind, string>> _dataIndex;
+
+        public static readonly DependencyProperty KindProperty
+            = DependencyProperty.Register(nameof(Kind), typeof(PackIconZondiconsKind), typeof(PathIconZondicons), new PropertyMetadata(default(PackIconZondiconsKind), KindPropertyChangedCallback));
+
+        private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
+            ((PathIconZondicons)dependencyObject).UpdateData();
+        }
+
+        /// <summary>
+        /// Gets or sets the icon to display.
+        /// </summary>
+        public PackIconZondiconsKind Kind
+        {
+            get { return (PackIconZondiconsKind)GetValue(KindProperty); }
+            set { SetValue(KindProperty, value); }
+        }
+
+        public PathIconZondicons()
+        {
+            if (_dataIndex == null)
+            {
+                _dataIndex = new Lazy<IDictionary<PackIconZondiconsKind, string>>(PackIconZondiconsDataFactory.Create);
+            }
+        }
+
+        protected override void UpdateData()
+        {
+            string data = null;
+            _dataIndex.Value?.TryGetValue(Kind, out data);
+            if (string.IsNullOrEmpty(data))
+            {
+                this.Data = default(Geometry);
+            }
+            else
+            {
+                BindingOperations.SetBinding(this, PathIcon.DataProperty, new Binding() {Source = data, Mode = BindingMode.OneTime});
+            }
         }
     }
 }

--- a/src/sign.cake
+++ b/src/sign.cake
@@ -1,5 +1,5 @@
 #module nuget:?package=Cake.DotNetTool.Module
-#tool "dotnet:?package=NuGetKeyVaultSignTool&version=1.2.18"
+#tool "dotnet:?package=NuGetKeyVaultSignTool&version=2.0.2"
 #tool "dotnet:?package=AzureSignTool&version=2.0.17"
 
 void SignFiles(IEnumerable<FilePath> files, string description, string repoUrl)


### PR DESCRIPTION
- Changing the PackIcon classes to no longer derive from a generic class.
- Changing the PackIconExtension classes to no longer derive from a generic class.
- Changing the PathIcon classes to no longer derive from a generic class.
- Set Horizontal- and VerticalAlignement for PathIcon to Left and Top

Closes #154 
