### PR TITLE
AdvancedFiltering

### DIFF
--- a/src/MahApps.Metro.IconPacks.Browser/Styles/CustomTabControl.xaml
+++ b/src/MahApps.Metro.IconPacks.Browser/Styles/CustomTabControl.xaml
@@ -239,7 +239,19 @@
                          BorderThickness="0 0 0 1"
                          SnapsToDevicePixels="True"
                          Background="Transparent"
-                         Text="{Binding MainViewModel.FilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Delay=300}" />
+                         Text="{Binding MainViewModel.FilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Delay=300}" >
+                    <TextBox.ToolTip>
+                        <StackPanel>
+                            <TextBlock Text="Advanced filtering:" Foreground="{DynamicResource MahApps.Brushes.Accent}" FontWeight="Bold" />
+                            <TextBlock>
+                                <Run Text="Use these chars to match all substrings: &#x09;" /> <Run FontFamily="Courier New" Text="'&amp;' '+' ',' ';'"/>
+                            </TextBlock>
+                            <TextBlock>
+                                <Run Text="Use this chars to match any substring: &#x09;" /> <Run FontFamily="Courier New" Text="'|'" />
+                            </TextBlock>
+                        </StackPanel>
+                    </TextBox.ToolTip>
+                </TextBox>
 
                 <StackPanel Margin="10 5 10 0"
                             VerticalAlignment="Top"

--- a/src/MahApps.Metro.IconPacks.Browser/ViewModels/IconPackViewModel.cs
+++ b/src/MahApps.Metro.IconPacks.Browser/ViewModels/IconPackViewModel.cs
@@ -73,9 +73,27 @@ namespace MahApps.Metro.IconPacks.Browser.ViewModels
 
         private bool FilterIconsPredicate(string filterText, IIconViewModel iconViewModel)
         {
-            return string.IsNullOrWhiteSpace(filterText)
-                   || iconViewModel.Name.IndexOf(filterText, StringComparison.CurrentCultureIgnoreCase) >= 0
-                   || (!string.IsNullOrWhiteSpace(iconViewModel.Description) && iconViewModel.Description.IndexOf(filterText, StringComparison.CurrentCultureIgnoreCase) >= 0);
+            if (string.IsNullOrWhiteSpace(filterText))
+            {
+                return true;
+            }
+            else
+            {
+                var filterSubStrings = filterText.Split(new char[] { '+', ',', ';', '&' }, StringSplitOptions.RemoveEmptyEntries);
+
+                foreach (var filterSubString in filterSubStrings)
+                {
+                    var filterOrSubStrings = filterSubString.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+
+                    var isInName = filterOrSubStrings.Any(x => iconViewModel.Name.IndexOf(x.Trim(), StringComparison.CurrentCultureIgnoreCase) >= 0);
+                    var isInDescription = filterOrSubStrings.Any(x => (iconViewModel.Description?.IndexOf(x.Trim(), StringComparison.CurrentCultureIgnoreCase) ?? -1) >= 0);
+
+                    if (!(isInName || isInDescription)) return false;
+                }
+
+                return true;
+
+            }
         }
 
         private static string GetDescription(Enum value)


### PR DESCRIPTION
## What does this PR do?
This PR allows the `FilterTextBox` to support advanced filtering

- AND-Operator: Use these chars to match all the substrings: `'&', '+', ',', ';'`
- OR-Operator: Use this char to match any substring: `'|'`

## Example

Typing `delete | remove + user` will return all Icons which contains `delete` OR `remove` AND `user`

![image](https://user-images.githubusercontent.com/47110241/94432045-708dde80-0196-11eb-9676-fdd0a59c996b.png)

## Closes
Closes #219 