### PR TITLE
Tweaked xmlns prefix to match previous automatic prefix

### DIFF
--- a/src/MahApps.Metro.IconPacks/Properties/AssemblyInfo.cs
+++ b/src/MahApps.Metro.IconPacks/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Windows;
 using System.Windows.Markup;
 
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
-[assembly: XmlnsPrefix(@"http://metro.mahapps.com/winfx/xaml/iconpacks", "iconpacks")]
+[assembly: XmlnsPrefix(@"http://metro.mahapps.com/winfx/xaml/iconpacks", "iconPacks")]
 [assembly: XmlnsDefinition(@"http://metro.mahapps.com/winfx/xaml/iconpacks", "MahApps.Metro.IconPacks")]
 [assembly: XmlnsDefinition(@"http://metro.mahapps.com/winfx/xaml/iconpacks", "MahApps.Metro.IconPacks.Converter")]
 #endif


### PR DESCRIPTION
### What changed?
I changed the `XmlnsPrefix` from `iconpacks` to `iconPacks`.

### Why?
Before `XmlnsPrefix` was added to the `AssemblyInfo`, VS automatically used `iconPacks` as the prefix. As we have been using this icon pack for years, this means our code base has hundreds of uses of the previous prefix.

Any new uses now automatically adds the new prefix, meaning we will have different prefixes in different files for the same package. This causes issues when copying XAML between files that are using different prefixes.

Another annoying thing is that out-of-the-box ReSharper views the new prefix as a typo. Meaning we'll need to either keep renaming the prefix to the old prefix in every new file, or add `iconpacks` to the custom dictionary. The latter is of course the easiest, but feels unnecessary.

For these reasons, in my opinion, the best solution is to revert back to the previous prefix.