### PR TITLE
fix: #303 #292 Drop the UWP support

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: Major
 assembly-file-versioning-scheme: MajorMinorPatchTag
-next-version: 5.2.0
+next-version: 6.0.0
 mode: ContinuousDeployment
 branches:
   master:

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -6,12 +6,26 @@
 
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFrameworks>net8.0-windows;net6.0-windows;net47;net462;uap10.0.18362</TargetFrameworks>
+        <!--<TargetFrameworks>net8.0-windows;net6.0-windows;net47;net462;uap10.0.18362</TargetFrameworks>-->
+        <TargetFrameworks>net8.0-windows;net6.0-windows;net47;net462</TargetFrameworks>
+
+		<IsUwp Condition="'$(IsUwp)'==''">false</IsUwp>
+		<IsUwp Condition="$(TargetFramework.Contains('10.0'))">true</IsUwp>
+		<IsWpf Condition="'$(IsWpf)'==''">false</IsWpf>
+		<IsWpf Condition="'$(IsUwp)' == 'false'">true</IsWpf>
+
+        <IsBuildingForLegacyFramework>false</IsBuildingForLegacyFramework>
+        <IsBuildingForLegacyFramework Condition="$(TargetFramework.StartsWith('net4'))">true</IsBuildingForLegacyFramework>
+
+        <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+
         <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <GenerateLibraryLayout>true</GenerateLibraryLayout>
-        <AutoGenerateBindingRedirects Condition=" $(TargetFramework.StartsWith('net4')) or $(TargetFramework.StartsWith('uap')) ">true</AutoGenerateBindingRedirects>
+        <AutoGenerateBindingRedirects Condition="'$(IsBuildingForLegacyFramework)' == 'true' or '$(IsUwp)' == 'true'">true</AutoGenerateBindingRedirects>
+
         <LangVersion>latest</LangVersion>
+
         <NoWarn>$(NoWarn);CS1591;CS0618</NoWarn>
         <NoError>$(NoError);CS1591;CS0618</NoError>
     </PropertyGroup>
@@ -22,12 +36,12 @@
     </PropertyGroup>
 
     <!-- .NET Framework and Core -->
-    <PropertyGroup Condition=" !$(TargetFramework.StartsWith('uap')) ">
+    <PropertyGroup Condition="'$(IsWpf)' == 'true'">
         <UseWpf>true</UseWpf>
     </PropertyGroup>
 
     <!-- UAP -->
-    <PropertyGroup Condition=" $(TargetFramework.StartsWith('uap')) ">
+    <PropertyGroup Condition="'$(IsUwp)' == 'true'">
         <DefaultTargetPlatformVersion>18362</DefaultTargetPlatformVersion>
         <DefaultTargetPlatformMinVersion>18362</DefaultTargetPlatformMinVersion>
         <UseWindowsDesktopSdk>true</UseWindowsDesktopSdk>
@@ -36,9 +50,6 @@
         <!-- This is valid for platforms other than .NET Framework (and is needed for the UWP targets -->
         <NoWarn>$(NoWarn);8002;CS0618</NoWarn>
         <NoError>$(NoError);CS0618</NoError>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" $(TargetFramework.StartsWith('uap')) and '$(Configuration)' == 'Release' ">
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/src/MahApps.Metro.IconPacks.BootstrapIcons/MahApps.Metro.IconPacks.BootstrapIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.BootstrapIcons/MahApps.Metro.IconPacks.BootstrapIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);BOOTSTRAPICONS</DefineConstants>
         <IconsName>BootstrapIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.BootstrapIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.BoxIcons/MahApps.Metro.IconPacks.BoxIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.BoxIcons/MahApps.Metro.IconPacks.BoxIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);BOXICONS</DefineConstants>
         <IconsName>BoxIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.BoxIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.CircumIcons/MahApps.Metro.IconPacks.CircumIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.CircumIcons/MahApps.Metro.IconPacks.CircumIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);CIRCUMICONS</DefineConstants>
         <IconsName>CircumIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.CircumIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Codicons/MahApps.Metro.IconPacks.Codicons.csproj
+++ b/src/MahApps.Metro.IconPacks.Codicons/MahApps.Metro.IconPacks.Codicons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);CODICONS</DefineConstants>
         <IconsName>Codicons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Codicons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Coolicons/MahApps.Metro.IconPacks.Coolicons.csproj
+++ b/src/MahApps.Metro.IconPacks.Coolicons/MahApps.Metro.IconPacks.Coolicons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);COOLICONS</DefineConstants>
         <IconsName>Coolicons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Coolicons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
+++ b/src/MahApps.Metro.IconPacks.Core/MahApps.Metro.IconPacks.Core.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <AssemblyName>MahApps.Metro.IconPacks.Core</AssemblyName>
         <Title>MahApps.Metro.IconPacks.Core</Title>
@@ -10,21 +9,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net47'" />
-        <Reference Include="System.Web.Extensions" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net47'" />
+        <Reference Include="System.Web" Condition="'$(IsBuildingForLegacyFramework)' == 'true'" />
+        <Reference Include="System.Web.Extensions" Condition="'$(IsBuildingForLegacyFramework)' == 'true'" />
         <PackageReference Include="System.Text.Json" Version="6.0.10" Condition="'$(TargetFramework)' == 'net6.0-windows'" />
-        <PackageReference Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'net8.0-windows' or '$(TargetFramework)' == 'uap10.0.18362'" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'net8.0-windows' or '$(IsUwp)' == 'true'" />
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="PathIcon*.cs" />
         <Compile Remove="Attributes\DescriptionAttribute.cs" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="Converter\PackIconKindToImageConverterBase.cs;PackIconImageExtension.cs;PackIconCursorExtension.cs;PackIconCursorHelper.cs" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />
         <Page Include="**\*.xaml" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" SubType="Designer" Generator="MSBuild:Compile" />

--- a/src/MahApps.Metro.IconPacks.Entypo/MahApps.Metro.IconPacks.Entypo.csproj
+++ b/src/MahApps.Metro.IconPacks.Entypo/MahApps.Metro.IconPacks.Entypo.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);ENTYPO</DefineConstants>
         <IconsName>Entypo</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Entypo</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.EvaIcons/MahApps.Metro.IconPacks.EvaIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.EvaIcons/MahApps.Metro.IconPacks.EvaIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);EVAICONS</DefineConstants>
         <IconsName>EvaIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.EvaIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.FeatherIcons/MahApps.Metro.IconPacks.FeatherIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.FeatherIcons/MahApps.Metro.IconPacks.FeatherIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);FEATHERICONS</DefineConstants>
         <IconsName>FeatherIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.FeatherIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.FileIcons/MahApps.Metro.IconPacks.FileIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.FileIcons/MahApps.Metro.IconPacks.FileIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);FILEICONS</DefineConstants>
         <IconsName>FileIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.FileIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.FontAwesome/MahApps.Metro.IconPacks.FontAwesome.csproj
+++ b/src/MahApps.Metro.IconPacks.FontAwesome/MahApps.Metro.IconPacks.FontAwesome.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);FONTAWESOME</DefineConstants>
         <IconsName>FontAwesome</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.FontAwesome</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Fontaudio/MahApps.Metro.IconPacks.Fontaudio.csproj
+++ b/src/MahApps.Metro.IconPacks.Fontaudio/MahApps.Metro.IconPacks.Fontaudio.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);FONTAUDIO</DefineConstants>
         <IconsName>Fontaudio</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Fontaudio</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Fontisto/MahApps.Metro.IconPacks.Fontisto.csproj
+++ b/src/MahApps.Metro.IconPacks.Fontisto/MahApps.Metro.IconPacks.Fontisto.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);FONTISTO</DefineConstants>
         <IconsName>Fontisto</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Fontisto</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.ForkAwesome/MahApps.Metro.IconPacks.ForkAwesome.csproj
+++ b/src/MahApps.Metro.IconPacks.ForkAwesome/MahApps.Metro.IconPacks.ForkAwesome.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);FORKAWESOME</DefineConstants>
         <IconsName>ForkAwesome</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.ForkAwesome</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.GameIcons/MahApps.Metro.IconPacks.GameIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.GameIcons/MahApps.Metro.IconPacks.GameIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);GAMEICONS</DefineConstants>
         <IconsName>GameIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.GameIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Ionicons/MahApps.Metro.IconPacks.Ionicons.csproj
+++ b/src/MahApps.Metro.IconPacks.Ionicons/MahApps.Metro.IconPacks.Ionicons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);IONICONS</DefineConstants>
         <IconsName>Ionicons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Ionicons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.JamIcons/MahApps.Metro.IconPacks.JamIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.JamIcons/MahApps.Metro.IconPacks.JamIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);JAMICONS</DefineConstants>
         <IconsName>JamIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.JamIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Lucide/MahApps.Metro.IconPacks.Lucide.csproj
+++ b/src/MahApps.Metro.IconPacks.Lucide/MahApps.Metro.IconPacks.Lucide.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);LUCIDE</DefineConstants>
         <IconsName>Lucide</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Lucide</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Material/MahApps.Metro.IconPacks.Material.csproj
+++ b/src/MahApps.Metro.IconPacks.Material/MahApps.Metro.IconPacks.Material.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);MATERIAL</DefineConstants>
         <IconsName>Material</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Material</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.MaterialDesign/MahApps.Metro.IconPacks.MaterialDesign.csproj
+++ b/src/MahApps.Metro.IconPacks.MaterialDesign/MahApps.Metro.IconPacks.MaterialDesign.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);MATERIALDESIGN</DefineConstants>
         <IconsName>MaterialDesign</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.MaterialDesign</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.MaterialLight/MahApps.Metro.IconPacks.MaterialLight.csproj
+++ b/src/MahApps.Metro.IconPacks.MaterialLight/MahApps.Metro.IconPacks.MaterialLight.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);MATERIALLIGHT</DefineConstants>
         <IconsName>MaterialLight</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.MaterialLight</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.MemoryIcons/MahApps.Metro.IconPacks.MemoryIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.MemoryIcons/MahApps.Metro.IconPacks.MemoryIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);MEMORYICONS</DefineConstants>
         <IconsName>MemoryIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.MemoryIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Microns/MahApps.Metro.IconPacks.Microns.csproj
+++ b/src/MahApps.Metro.IconPacks.Microns/MahApps.Metro.IconPacks.Microns.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);MICRONS</DefineConstants>
         <IconsName>Microns</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Microns</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Modern/MahApps.Metro.IconPacks.Modern.csproj
+++ b/src/MahApps.Metro.IconPacks.Modern/MahApps.Metro.IconPacks.Modern.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);MODERN</DefineConstants>
         <IconsName>Modern</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Modern</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Octicons/MahApps.Metro.IconPacks.Octicons.csproj
+++ b/src/MahApps.Metro.IconPacks.Octicons/MahApps.Metro.IconPacks.Octicons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);OCTICONS</DefineConstants>
         <IconsName>Octicons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Octicons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.PhosphorIcons/MahApps.Metro.IconPacks.PhosphorIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.PhosphorIcons/MahApps.Metro.IconPacks.PhosphorIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);PHOSPHORICONS</DefineConstants>
         <IconsName>PhosphorIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.PhosphorIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.PicolIcons/MahApps.Metro.IconPacks.PicolIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.PicolIcons/MahApps.Metro.IconPacks.PicolIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);PICOLICONS</DefineConstants>
         <IconsName>PicolIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.PicolIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.PixelartIcons/MahApps.Metro.IconPacks.PixelartIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.PixelartIcons/MahApps.Metro.IconPacks.PixelartIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);PIXELARTICONS</DefineConstants>
         <IconsName>PixelartIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.PixelartIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.RPGAwesome/MahApps.Metro.IconPacks.RPGAwesome.csproj
+++ b/src/MahApps.Metro.IconPacks.RPGAwesome/MahApps.Metro.IconPacks.RPGAwesome.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);RPGAWESOME</DefineConstants>
         <IconsName>RPGAwesome</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.RPGAwesome</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.RadixIcons/MahApps.Metro.IconPacks.RadixIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.RadixIcons/MahApps.Metro.IconPacks.RadixIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);RADIXICONS</DefineConstants>
         <IconsName>RadixIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.RadixIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.RemixIcon/MahApps.Metro.IconPacks.RemixIcon.csproj
+++ b/src/MahApps.Metro.IconPacks.RemixIcon/MahApps.Metro.IconPacks.RemixIcon.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);REMIXICON</DefineConstants>
         <IconsName>RemixIcon</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.RemixIcon</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.SimpleIcons/MahApps.Metro.IconPacks.SimpleIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.SimpleIcons/MahApps.Metro.IconPacks.SimpleIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);SIMPLEICONS</DefineConstants>
         <IconsName>SimpleIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.SimpleIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Typicons/MahApps.Metro.IconPacks.Typicons.csproj
+++ b/src/MahApps.Metro.IconPacks.Typicons/MahApps.Metro.IconPacks.Typicons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);TYPICONS</DefineConstants>
         <IconsName>Typicons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Typicons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Unicons/MahApps.Metro.IconPacks.Unicons.csproj
+++ b/src/MahApps.Metro.IconPacks.Unicons/MahApps.Metro.IconPacks.Unicons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);UNICONS</DefineConstants>
         <IconsName>Unicons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Unicons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.VaadinIcons/MahApps.Metro.IconPacks.VaadinIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.VaadinIcons/MahApps.Metro.IconPacks.VaadinIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);VAADINICONS</DefineConstants>
         <IconsName>VaadinIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.VaadinIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.WeatherIcons/MahApps.Metro.IconPacks.WeatherIcons.csproj
+++ b/src/MahApps.Metro.IconPacks.WeatherIcons/MahApps.Metro.IconPacks.WeatherIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);WEATHERICONS</DefineConstants>
         <IconsName>WeatherIcons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.WeatherIcons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks.Zondicons/MahApps.Metro.IconPacks.Zondicons.csproj
+++ b/src/MahApps.Metro.IconPacks.Zondicons/MahApps.Metro.IconPacks.Zondicons.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);ZONDICONS</DefineConstants>
         <IconsName>Zondicons</IconsName>
         <AssemblyName>MahApps.Metro.IconPacks.Zondicons</AssemblyName>
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Compile Remove="Path*.*" />
         <Page Generator="MSBuild:Compile" Include="Themes\WPF\*.xaml" Link="Themes\%(RecursiveDir)%(Filename)%(Extension)" SubType="Designer" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" />
     </ItemGroup>
 
     <!-- UWP Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' == 'uap'">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*Image*.cs;*Cursor*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />

--- a/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
+++ b/src/MahApps.Metro.IconPacks/MahApps.Metro.IconPacks.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras">
-    <!-- Project properties -->
-    <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
         <DefineConstants>$(DefineConstants);ALL</DefineConstants>
         <AssemblyName>MahApps.Metro.IconPacks</AssemblyName>
         <Title>MahApps.Metro.IconPacks</Title>
@@ -50,7 +50,7 @@
     </ItemGroup>
 
     <!-- WPF Items include -->
-    <ItemGroup Condition="'$(_SdkShortFrameworkIdentifier)' != 'uap'">
+    <ItemGroup Condition="'$(IsWpf)' == 'true'">
         <None Remove="**\*.rd.xml" />
         <Page Generator="MSBuild:Compile"
               Include="Themes\WPF\*.xaml"
@@ -63,7 +63,7 @@
         <Compile Remove="**\*Extension*.cs" />
     </ItemGroup> -->
 
-    <ItemGroup Condition=" '$(_SdkShortFrameworkIdentifier)' == 'uap' ">
+    <ItemGroup Condition="'$(IsUwp)' == 'true'">
         <Compile Remove="*.cs" />
         <Compile Remove="Themes\**\*.*" />
         <EmbeddedResource Include="Properties\$(AssemblyName).rd.xml" />
@@ -85,7 +85,7 @@
             <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'All'))" />
         </ItemGroup>
     </Target>
-    <Target Name="GetMyPackageFiles" Condition=" $(TargetFramework.StartsWith('uap')) ">
+    <Target Name="GetMyPackageFiles" Condition="'$(IsUwp)' == 'true'">
         <ItemGroup>
 
             <BuildOutputInPackage Include="$(OutDir)MahApps.Metro.IconPacks.BootstrapIcons\*.*">


### PR DESCRIPTION
I will drop the support in the next version (6.0).

But I will try to create a new separate repository (or again here) for UWP and maybe WinUI too.

If anyone want to help me to create this with he new Sdk and .Net 9 then let me know :-D

Closes #303 
Closes #292 